### PR TITLE
Space-Membership-Regeln spezifizieren

### DIFF
--- a/01-wot-identity/003-did-resolution.md
+++ b/01-wot-identity/003-did-resolution.md
@@ -267,7 +267,7 @@ Der X25519 Encryption Key wird über einen separaten HKDF-Pfad abgeleitet (siehe
 Der Resolver befüllt `keyAgreement` aus externen Quellen:
 
 - **QR-Code:** Das `enc`-Feld (siehe [Trust 002](../02-wot-trust/002-verifikation.md)) wird in `keyAgreement` eingetragen
-- **Profil-Service:** Das `encryptionPublicKey`-Feld (siehe [Sync 004](../03-wot-sync/004-discovery.md)) wird in `keyAgreement` eingetragen
+- **Profil-Service:** Das eingebettete DID-Dokument (siehe [Sync 004](../03-wot-sync/004-discovery.md)) liefert `keyAgreement`
 
 Dies ist ein **bekannter Workaround** für die Phase-1-Architektur. In Phase 2 (did:webvh) steht der Encryption Key direkt im DID-Dokument.
 

--- a/02-wot-trust/001-attestations.md
+++ b/02-wot-trust/001-attestations.md
@@ -131,13 +131,13 @@ Die Attestation gehört dem Subject. Konkret:
 
 - Der Issuer erstellt und signiert die Attestation (als JWS)
 - Die Attestation wird verschlüsselt an den Subject/Holder übermittelt
-- Der Holder speichert den JWS lokal
-- Der Holder entscheidet ob er sie veröffentlicht
+- Der Holder speichert den JWS lokal in seiner Wallet bzw. im Personal Doc
+- Der Holder entscheidet ob er sie veröffentlicht, z.B. über das öffentliche Profil (`/p/{did}/a`, siehe [Sync 004](../03-wot-sync/004-discovery.md))
 - Der Issuer behält keine Kopie (kann aber natürlich eine behalten)
 
 ### Akzeptanz
 
-Der Holder hat ein lokales `public`-Flag pro Attestation. Nicht veröffentlichte Attestations sind unsichtbar für Dritte (nicht im Profil-Service). Das Flag ist **nicht Teil des VC** und wird **nicht signiert** — es ist eine reine lokale Entscheidung, gespeichert als Metadaten neben dem JWS im Personal Doc.
+Der Holder hat ein lokales `public`-Flag pro Attestation. Nicht veröffentlichte Attestations bleiben in der Wallet bzw. im Personal Doc und sind unsichtbar für Dritte (nicht im Profil-Service). Das Flag ist **nicht Teil des VC** und wird **nicht signiert** — es ist eine reine lokale Entscheidung, gespeichert als Metadaten neben dem JWS im Personal Doc.
 
 ## Unveränderlichkeit
 

--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -224,7 +224,7 @@ Die Verification-Attestation wird als DIDComm-Nachricht über den Broker zugeste
 Der X25519 Encryption Public Key erreicht andere Teilnehmer auf zwei Wegen:
 
 1. **QR-Code (In-Person):** Das `enc`-Feld im QR-Code — sofort verfügbar, auch offline
-2. **Profil-Service (Online):** Kanonisch über `didDocument.keyAgreement`; optional zusätzlich als `profile.encryptionPublicKey` Alias — für Kontakte die nicht per QR-Code ausgetauscht wurden (z.B. Space-Einladungen über Dritte)
+2. **Profil-Service (Online):** Über `didDocument.keyAgreement` — für Kontakte die nicht per QR-Code ausgetauscht wurden (z.B. Space-Einladungen über Dritte)
 
 Siehe [Sync 001: Encryption Key Discovery](../03-wot-sync/001-verschluesselung.md#encryption-key-discovery) für Details.
 

--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -123,6 +123,18 @@ Der Empfänger einer Verification-Attestation prüft:
 
 Die aktive Challenge (mindestens `nonce` und `ts`) MUSS nur bis zur Verifikation oder Regenerierung des QR-Codes lokal gehalten werden. Sie MUSS nicht dauerhaft persistiert werden. Bei App-Neustart ist der sichere Fallback, alte aktive Challenges zu verwerfen und einen neuen QR-Code zu erzeugen.
 
+### Acceptance Gate fuer Online-Verifikation (MUSS)
+
+Eine eingehende Verification-Attestation DARF im Online-Ein-QR-Scan-Flow nur dann als In-Person-Verifikation akzeptiert oder automatisch zur Gegen-Verifikation angeboten werden, wenn alle Bedingungen erfuellt sind:
+
+1. Die Signatur der Attestation ist gueltig.
+2. Die Attestation richtet sich an die lokale DID.
+3. Die Attestation-ID (`jti`) enthaelt eine lokal aktive, noch nicht verbrauchte Challenge-Nonce.
+4. Die aktive Challenge ist zeitlich gueltig.
+5. Die Nonce wurde noch nicht in der Nonce-History konsumiert.
+
+Fehlt eine aktive Challenge-Nonce, MUSS die Attestation als ungebundene Remote-Verifikation behandelt werden. Sie DARF gespeichert oder dem User als separate Remote-Anfrage angezeigt werden, aber sie DARF NICHT als Beweis fuer eine physische Begegnung gelten. Damit wird verhindert, dass beliebige signierte Verification-Attestations als In-Person-Begegnung in den Trust Graph gelangen.
+
 ### Nonce-History (MUSS)
 
 Empfänger MÜSSEN eine Liste bereits verwendeter Nonces führen um Replay-Angriffe zu verhindern. Ohne diese Prüfung könnte ein Angreifer eine aufgezeichnete gültige Attestation erneut vorlegen.
@@ -212,7 +224,7 @@ Die Verification-Attestation wird als DIDComm-Nachricht über den Broker zugeste
 Der X25519 Encryption Public Key erreicht andere Teilnehmer auf zwei Wegen:
 
 1. **QR-Code (In-Person):** Das `enc`-Feld im QR-Code — sofort verfügbar, auch offline
-2. **Profil-Service (Online):** Veröffentlicht im Nutzerprofil unter `encryptionPublicKey` — für Kontakte die nicht per QR-Code ausgetauscht wurden (z.B. Space-Einladungen über Dritte)
+2. **Profil-Service (Online):** Kanonisch über `didDocument.keyAgreement`; optional zusätzlich als `profile.encryptionPublicKey` Alias — für Kontakte die nicht per QR-Code ausgetauscht wurden (z.B. Space-Einladungen über Dritte)
 
 Siehe [Sync 001: Encryption Key Discovery](../03-wot-sync/001-verschluesselung.md#encryption-key-discovery) für Details.
 

--- a/03-wot-sync/001-verschluesselung.md
+++ b/03-wot-sync/001-verschluesselung.md
@@ -52,7 +52,7 @@ Die birationale Abbildung (Ed25519 → Curve25519 → X25519) ist NICHT erlaubt 
 
 Der X25519 Encryption Public Key ist **nicht** aus der `did:key` ableitbar — die DID kodiert nur den Ed25519 Signing Key. Der Encryption Key wird über einen separaten HKDF-Pfad abgeleitet und muss explizit transportiert werden.
 
-Der Key wird entweder im `enc`-Feld der QR-Challenge ([Trust 002](../02-wot-trust/002-verifikation.md)) oder als `keyAgreement` im DID-Dokument/Profil-Service ([Identity 003](../01-wot-identity/003-did-resolution.md), [Sync 004](004-discovery.md)) transportiert.
+Der Key wird entweder im `enc`-Feld der QR-Challenge ([Trust 002](../02-wot-trust/002-verifikation.md)) oder als `keyAgreement` im DID-Dokument/Profil-Service ([Identity 003](../01-wot-identity/003-did-resolution.md), [Sync 004](004-discovery.md)) transportiert. Ein Profil-Service DARF zusaetzlich `profile.encryptionPublicKey` als Base64URL-Alias ausliefern; dieser Alias MUSS dem kanonischen `didDocument.keyAgreement[#enc-0]` entsprechen.
 
 Clients MÜSSEN den Encryption Key nach dem ersten Empfang lokal cachen. In JWE-Headern (`kid`, `skid`) wird die DID ohne Fragment verwendet — die Auflösung zum X25519-Key geschieht protokollintern über den lokalen Cache, nicht über did:key-Fragment-Auflösung.
 

--- a/03-wot-sync/001-verschluesselung.md
+++ b/03-wot-sync/001-verschluesselung.md
@@ -52,7 +52,7 @@ Die birationale Abbildung (Ed25519 → Curve25519 → X25519) ist NICHT erlaubt 
 
 Der X25519 Encryption Public Key ist **nicht** aus der `did:key` ableitbar — die DID kodiert nur den Ed25519 Signing Key. Der Encryption Key wird über einen separaten HKDF-Pfad abgeleitet und muss explizit transportiert werden.
 
-Der Key wird entweder im `enc`-Feld der QR-Challenge ([Trust 002](../02-wot-trust/002-verifikation.md)) oder als `keyAgreement` im DID-Dokument/Profil-Service ([Identity 003](../01-wot-identity/003-did-resolution.md), [Sync 004](004-discovery.md)) transportiert. Ein Profil-Service DARF zusaetzlich `profile.encryptionPublicKey` als Base64URL-Alias ausliefern; dieser Alias MUSS dem kanonischen `didDocument.keyAgreement[#enc-0]` entsprechen.
+Der Key wird entweder im `enc`-Feld der QR-Challenge ([Trust 002](../02-wot-trust/002-verifikation.md)) oder als `keyAgreement` im DID-Dokument des Profil-Service ([Identity 003](../01-wot-identity/003-did-resolution.md), [Sync 004](004-discovery.md)) transportiert. Das soziale Profil enthaelt keine redundanten kryptographischen Schluessel.
 
 Clients MÜSSEN den Encryption Key nach dem ersten Empfang lokal cachen. In JWE-Headern (`kid`, `skid`) wird die DID ohne Fragment verwendet — die Auflösung zum X25519-Key geschieht protokollintern über den lokalen Cache, nicht über did:key-Fragment-Auflösung.
 

--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -139,6 +139,20 @@ Klartext (CRDT-Update, z.B. Yjs-Binary)
 
 Der entschlüsselte Payload ist opak. Der CRDT-Typ steht in der Space-Metadata, nicht im Log-Eintrag. Peers schreiben nur in den Log ihrer eigenen `deviceId`; empfangene Einträge bleiben unter der `deviceId` des Autors gespeichert.
 
+### Snapshots und Full-State-Nachrichten
+
+`wot-sync@0.1` normiert den Append-only Log als Interop-Baseline. Implementierungen DÜRFEN zusaetzlich Snapshots, Full-State-Nachrichten oder Vault-Backups verwenden, um Restore und Multi-Device-Catch-Up zu beschleunigen. Solche Optimierungen ersetzen den Log nicht als Konformitaetsanforderung.
+
+Wenn eine Implementierung einen Snapshot oder Full-State-Payload uebertraegt, gelten dieselben Sicherheitsregeln wie fuer Log-Payloads:
+
+- Der Payload MUSS mit dem Space Content Key der angegebenen `keyGeneration` verschluesselt sein.
+- Das verschluesselte Format MUSS `Nonce | Ciphertext | Auth Tag` oder eine aequivalente eindeutig parsebare Form transportieren.
+- Die Autorenschaft oder Transportberechtigung MUSS separat authentifiziert sein (z.B. Envelope-JWS, authentifizierte Broker-Verbindung plus Capability, oder inneres JWS).
+- Ein Empfaenger DARF einen Snapshot nur mergen, wenn er zur erwarteten `docId` und `keyGeneration` passt.
+- Peers MUESSEN weiterhin Log-Eintraege mit `authorKid`, `seq`, `deviceId` und `keyGeneration` verifizieren koennen.
+
+Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format.
+
 ## Sync-Modi
 
 Das Log-Protokoll unterstützt Live-Sync und Catch-Up. Peers tauschen Heads pro `(docId, deviceId)` aus und senden fehlende Einträge. Push-Notifications sind nur ein Wecksignal; der Client holt fehlende Einträge danach über normalen Catch-Up (siehe [Sync 003](003-transport-und-broker.md#push-notifications)).

--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -151,7 +151,7 @@ Wenn eine Implementierung einen Snapshot oder Full-State-Payload uebertraegt, ge
 - Ein Empfaenger DARF einen Snapshot nur mergen, wenn er zur erwarteten `docId` und `keyGeneration` passt.
 - Peers MUESSEN weiterhin Log-Eintraege mit `authorKid`, `seq`, `deviceId` und `keyGeneration` verifizieren koennen.
 
-Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format.
+Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format. Ein Snapshot ist nicht autoritativ gegenueber bereits bekannten gueltigen CRDT-Operationen: Clients MUESSEN einen Snapshot ueber den jeweiligen CRDT mergen und DUERFEN ihn nicht verwenden, um lokal bekannte gueltige Log-Eintraege zurueckzurollen oder zu ersetzen. Wenn der CRDT-Import oder Merge eines Snapshots fehlschlaegt, MUSS der Client den Snapshot ignorieren und mit Log-/State-Sync fortfahren.
 
 ## Sync-Modi
 

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -403,6 +403,8 @@ Log-Einträge werden NICHT mit ECIES verschlüsselt — sie sind bereits mit dem
 
 Alle Type-URIs verwenden den Präfix `https://web-of-trust.de/protocols/`.
 
+Die Body-Formate fuer `space-invite/1.0`, `key-rotation/1.0` und `member-update/1.0` sind in [Sync 005](005-gruppen.md) spezifiziert und werden durch die Schemas `space-invite`, `key-rotation` und `member-update` beschrieben. Alle drei Nachrichtentypen sind Inbox-Nachrichten und MUESSEN nach [Sync 001 ECIES](001-verschluesselung.md#peer-to-peer-verschlüsselung-ecies) fuer den jeweiligen Empfaenger verschluesselt werden.
+
 ### Wire-Formate der Sync-Nachrichten
 
 #### `log-entry/1.0` — Neuer verschlüsselter Log-Eintrag

--- a/03-wot-sync/004-discovery.md
+++ b/03-wot-sync/004-discovery.md
@@ -23,11 +23,13 @@ Der Profil-Service verwaltet pro DID drei separate, aber zusammengehörige JWS-D
 
 | Ressource | Pfad | Inhalt |
 |---|---|---|
-| **Profil** | `/p/{did}` | Öffentliches Profil (Name, Bio, Avatar, Encryption Key, Broker-URLs, Protokolle) |
+| **Profil** | `/p/{did}` | DID-Dokument plus öffentliches Profil (Name, Bio, Avatar, Protokolle) |
 | **Verifikationen** | `/p/{did}/v` | Liste empfangener In-Person-Verifikationen (Beweis des Web-of-Trust-Graphen) |
-| **Attestations** | `/p/{did}/a` | Liste akzeptierter Attestations (öffentliche Aussagen die der Holder zeigen möchte) |
+| **Attestations** | `/p/{did}/a` | Liste bewusst veröffentlichter Attestations (öffentliche Aussagen die der Holder zeigen möchte) |
 
 Die Ressourcen werden unabhängig versioniert und aktualisiert.
+
+Empfangene Attestations landen zuerst in der privaten Wallet bzw. im Personal Doc des Holders. `/p/{did}/a` enthaelt nur Attestations, die der Holder bewusst veroeffentlicht hat. Der Profil-Service veroeffentlicht keine empfangenen Attestations automatisch.
 
 ### HTTP-API
 
@@ -95,7 +97,6 @@ Das Profil enthält das DID-Dokument und soziale Profil-Daten in einem signierte
     "name": "Alice",
     "bio": "Nachbarschaftsgarten",
     "avatar": "data:image/png;base64,...",
-    "encryptionPublicKey": "<Base64URL-kodierter X25519 Public Key, optionaler Alias>",
     "protocols": ["https://web-of-trust.de/protocols/attestation/1.0"]
   },
   "updatedAt": "2026-04-23T10:00:00Z"
@@ -147,10 +148,9 @@ Jede Ressource hat ihre eigene `version` (monoton, unabhängig von der Profil-Ve
 | `name` | String | Ja | Anzeigename |
 | `bio` | String | Nein | Kurzbeschreibung |
 | `avatar` | String | Nein | Avatar-Bild (Data-URL oder HTTPS-URL) |
-| `encryptionPublicKey` | String | Nein | Optionaler denormalisierter Alias fuer den X25519-Key aus `didDocument.keyAgreement`. Wenn vorhanden, MUSS er bytegleich dem `#enc-0` Key im DID-Dokument entsprechen. |
 | `protocols` | Array | Nein | Unterstützte Protokoll-URIs. Ermöglicht Clients zu erkennen, welche Extensions der Peer unterstützt. |
 
-Kanonische Quelle fuer Keys und Broker-URLs ist das `didDocument` (`keyAgreement` und `service`). Der optionale `profile.encryptionPublicKey` Alias existiert nur fuer einfache Discovery-Implementierungen und darf nicht als unabhaengige Quelle betrachtet werden. Wenn Alias und DID-Dokument widersprechen, MUSS der Client das Profil als inkonsistent behandeln und den Invite- oder Verschluesselungsversuch abbrechen.
+Kanonische Quelle fuer Keys und Broker-URLs ist ausschliesslich das `didDocument` (`keyAgreement` und `service`). Das `profile`-Objekt enthaelt soziale Metadaten und Protokoll-Hinweise, aber keine redundanten kryptographischen Schluessel. Clients MUESSEN Encryption-Key-Discovery ueber `didDocument.keyAgreement` durchfuehren.
 
 ### Signatur-Prüfung beim PUT
 

--- a/03-wot-sync/004-discovery.md
+++ b/03-wot-sync/004-discovery.md
@@ -95,6 +95,7 @@ Das Profil enthält das DID-Dokument und soziale Profil-Daten in einem signierte
     "name": "Alice",
     "bio": "Nachbarschaftsgarten",
     "avatar": "data:image/png;base64,...",
+    "encryptionPublicKey": "<Base64URL-kodierter X25519 Public Key, optionaler Alias>",
     "protocols": ["https://web-of-trust.de/protocols/attestation/1.0"]
   },
   "updatedAt": "2026-04-23T10:00:00Z"
@@ -146,9 +147,10 @@ Jede Ressource hat ihre eigene `version` (monoton, unabhängig von der Profil-Ve
 | `name` | String | Ja | Anzeigename |
 | `bio` | String | Nein | Kurzbeschreibung |
 | `avatar` | String | Nein | Avatar-Bild (Data-URL oder HTTPS-URL) |
+| `encryptionPublicKey` | String | Nein | Optionaler denormalisierter Alias fuer den X25519-Key aus `didDocument.keyAgreement`. Wenn vorhanden, MUSS er bytegleich dem `#enc-0` Key im DID-Dokument entsprechen. |
 | `protocols` | Array | Nein | Unterstützte Protokoll-URIs. Ermöglicht Clients zu erkennen, welche Extensions der Peer unterstützt. |
 
-Keys und Broker-URLs stehen ausschließlich im `didDocument` (`keyAgreement` und `service`). Es gibt keine separaten Top-Level-Felder für Encryption Keys oder Broker-URLs.
+Kanonische Quelle fuer Keys und Broker-URLs ist das `didDocument` (`keyAgreement` und `service`). Der optionale `profile.encryptionPublicKey` Alias existiert nur fuer einfache Discovery-Implementierungen und darf nicht als unabhaengige Quelle betrachtet werden. Wenn Alias und DID-Dokument widersprechen, MUSS der Client das Profil als inkonsistent behandeln und den Invite- oder Verschluesselungsversuch abbrechen.
 
 ### Signatur-Prüfung beim PUT
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -47,6 +47,17 @@ Beim Erstellen eines Spaces erzeugt der Client einen Space Content Key, ein Spac
 
 ## Einladung
 
+### Invitee-Key-Discovery (MUSS)
+
+Vor dem Erstellen einer Space-Einladung MUSS der Einladende den X25519 Encryption Public Key des Eingeladenen kennen. Erlaubte Quellen sind:
+
+1. ein zuvor gescannter QR-Code (`enc`, siehe [Trust 002](../02-wot-trust/002-verifikation.md)),
+2. ein lokal gecachter Contact-Key aus einer frueheren Begegnung,
+3. das DID-Dokument des Eingeladenen (`keyAgreement`, siehe [Identity 003](../01-wot-identity/003-did-resolution.md)),
+4. der optionale Profil-Service-Alias `profile.encryptionPublicKey`, falls er mit `didDocument.keyAgreement` uebereinstimmt (siehe [Sync 004](004-discovery.md)).
+
+Wenn kein Encryption Key aufloesbar ist oder Alias und DID-Dokument widersprechen, MUSS die Einladung abbrechen. Ein Client DARF in diesem Fall keine Space Content Keys unverschluesselt oder an eine falsche DID senden.
+
 ### Ablauf
 
 Einladungen werden als ECIES-verschlüsselte Inbox-Nachrichten transportiert. Jeder Member DARF eine Capability mit dem `spaceCapabilitySigningKey` für den Eingeladenen signieren; eine Admin-Signatur ist für Einladungen nicht erforderlich.
@@ -82,6 +93,14 @@ Inbox-Nachrichtentyp `space-invite`, verschlüsselt mit ECIES:
 }
 ```
 
+### Einladungs-Invarianten (MUSS)
+
+- `currentKeyGeneration` MUSS der hoechsten Generation in `spaceContentKeys` entsprechen.
+- Die `capability.generation` MUSS `currentKeyGeneration` entsprechen.
+- Die `capability.audience` MUSS der DID des Eingeladenen entsprechen.
+- `spaceContentKeys` MUSS alle Generationen enthalten, die der Eingeladene zum Entschluesseln der aktuell verfuegbaren Space-History benoetigt. Implementierungen duerfen alte Generationen weglassen, wenn sie dem Eingeladenen nur Zugriff ab einem spaeteren Snapshot geben; dann MUSS dieser Snapshot mit `currentKeyGeneration` entschluesselbar sein.
+- Der `spaceCapabilitySigningKey` DARF nur zur Ausstellung weiterer Broker-Capabilities verwendet werden, nicht zur Autoren-Authentifizierung.
+
 ### Annahme und Ablehnung
 
 Bei Annahme speichert der Empfänger Space Content Key, Space Capability Signing Key und Capability lokal, verbindet sich mit dem Heim-Broker und synchronisiert das Space-Dokument. Bei Ablehnung verwirft er die Nachricht.
@@ -109,6 +128,41 @@ Die Mitgliederliste wird als Teil der Sync-Daten gepflegt:
 
 Änderungen an der Mitgliederliste sind reguläre CRDT-Operationen.
 
+## Member-Update Nachricht
+
+`member-update/1.0` informiert bestehende oder entfernte Members ueber eine Mitgliedschaftsaenderung. Die authoritative Mitgliederliste bleibt das verschluesselte Space-Dokument; `member-update` ist ein Zustell- und UX-Signal, damit Clients sofort reagieren koennen.
+
+Inbox-Nachrichtentyp `member-update`, verschluesselt mit ECIES und mit innerem JWS signiert:
+
+```json
+{
+  "id": "uuid",
+  "typ": "application/didcomm-plain+json",
+  "type": "https://web-of-trust.de/protocols/member-update/1.0",
+  "from": "did:key:z6Mk...alice",
+  "to": ["did:key:z6Mk...bob"],
+  "created_time": 1776945600,
+  "body": {
+    "spaceId": "uuid",
+    "action": "added",
+    "memberDid": "did:key:z6Mk...bob",
+    "members": ["did:key:z6Mk...alice", "did:key:z6Mk...bob"],
+    "effectiveKeyGeneration": 3
+  }
+}
+```
+
+| Feld | Typ | Pflicht | Beschreibung |
+|------|-----|---------|-------------|
+| `spaceId` | UUID | Ja | Betroffener Space |
+| `action` | `added` \| `removed` | Ja | Art der Aenderung |
+| `memberDid` | DID | Ja | Betroffener Member |
+| `members` | Array<DID> | Ja | Mitgliederliste nach der Aenderung aus Sicht des Senders |
+| `effectiveKeyGeneration` | Integer | Ja | Key-Generation, ab der diese Aenderung wirksam ist |
+| `reason` | String | Nein | Optionale menschenlesbare Begruendung |
+
+Empfaenger MÜSSEN `member-update` gegen den naechsten Space-Sync verifizieren. Wenn die lokale CRDT-Mitgliederliste der Nachricht widerspricht, gewinnt das signierte und synchronisierte Space-Dokument. `member-update` allein DARF keine dauerhafte Membership-State-Aenderung erzwingen.
+
 ## Neue Admins hinzufügen
 
 Ein Admin DARF einen bestehenden Member zum Admin befördern. Dafür wird die Admin-Liste im CRDT um die Haupt-DID des neuen Admins erweitert und dessen abgeleitete Admin-DID per `admin-add` beim Broker registriert. `admin-add` MUSS mit einem bestehenden Admin Key signiert sein.
@@ -127,6 +181,13 @@ Bei Entfernung eines Members MUSS ein Admin:
 4. neuen Space Content Key, neuen Space Capability Signing Key und neue Capability via ECIES an alle verbleibenden Members verteilen.
 
 Neue Daten werden mit der neuen Generation verschlüsselt. Der entfernte Member besitzt weder neuen Content Key noch gültige Capability.
+
+Der Admin MUSS zusaetzlich `member-update` Nachrichten senden:
+
+- an den entfernten Member mit `action="removed"` und `effectiveKeyGeneration` der neuen Generation, damit der Client den Space lokal als verlassen/gesperrt markieren kann;
+- an die verbleibenden Members mit `action="removed"`, damit UIs und lokale Caches die Entfernung sofort anzeigen koennen.
+
+Verbleibende Members MUESSEN ausserdem eine `key-rotation` Nachricht mit dem neuen Content Key und der neuen Capability erhalten. Der entfernte Member DARF diese `key-rotation` Nachricht nicht erhalten.
 
 ### Key-Rotation Nachricht
 
@@ -153,6 +214,14 @@ Inbox-Nachrichtentyp `key-rotation`, verschlüsselt mit ECIES:
 Der Admin sendet eine `key-rotation` Nachricht an **jedes** verbleibende Mitglied einzeln.
 
 Alte Daten bleiben mit alten Space Content Keys lesbar. Rotation schuetzt nur zukuenftige Daten und zukuenftigen Broker-Zugriff.
+
+### Key-Rotation Invarianten (MUSS)
+
+- `generation` MUSS exakt die vorherige Space-Key-Generation plus eins sein.
+- Die enthaltene `capability.generation` MUSS `generation` entsprechen.
+- Der Broker MUSS nach erfolgreicher `space-rotate` Verarbeitung alte Capabilities ablehnen (`CAPABILITY_GENERATION_STALE`).
+- Clients MUESSEN neue Log-Eintraege nach Rotation mit der neuen `keyGeneration` schreiben.
+- Clients MUESSEN alte Log-Eintraege weiter mit der jeweils im Log-Eintrag angegebenen historischen `keyGeneration` entschluesseln.
 
 ## Concurrent-Verhalten
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -53,10 +53,9 @@ Vor dem Erstellen einer Space-Einladung MUSS der Einladende den X25519 Encryptio
 
 1. ein zuvor gescannter QR-Code (`enc`, siehe [Trust 002](../02-wot-trust/002-verifikation.md)),
 2. ein lokal gecachter Contact-Key aus einer frueheren Begegnung,
-3. das DID-Dokument des Eingeladenen (`keyAgreement`, siehe [Identity 003](../01-wot-identity/003-did-resolution.md)),
-4. der optionale Profil-Service-Alias `profile.encryptionPublicKey`, falls er mit `didDocument.keyAgreement` uebereinstimmt (siehe [Sync 004](004-discovery.md)).
+3. das DID-Dokument des Eingeladenen (`keyAgreement`, siehe [Identity 003](../01-wot-identity/003-did-resolution.md) und [Sync 004](004-discovery.md)).
 
-Wenn kein Encryption Key aufloesbar ist oder Alias und DID-Dokument widersprechen, MUSS die Einladung abbrechen. Ein Client DARF in diesem Fall keine Space Content Keys unverschluesselt oder an eine falsche DID senden.
+Wenn kein Encryption Key aufloesbar ist, MUSS die Einladung abbrechen. Ein Client DARF in diesem Fall keine Space Content Keys unverschluesselt oder an eine falsche DID senden.
 
 ### Ablauf
 
@@ -146,7 +145,6 @@ Inbox-Nachrichtentyp `member-update`, verschluesselt mit ECIES und mit innerem J
     "spaceId": "uuid",
     "action": "added",
     "memberDid": "did:key:z6Mk...bob",
-    "members": ["did:key:z6Mk...alice", "did:key:z6Mk...bob"],
     "effectiveKeyGeneration": 3
   }
 }
@@ -157,11 +155,10 @@ Inbox-Nachrichtentyp `member-update`, verschluesselt mit ECIES und mit innerem J
 | `spaceId` | UUID | Ja | Betroffener Space |
 | `action` | `added` \| `removed` | Ja | Art der Aenderung |
 | `memberDid` | DID | Ja | Betroffener Member |
-| `members` | Array<DID> | Ja | Mitgliederliste nach der Aenderung aus Sicht des Senders |
 | `effectiveKeyGeneration` | Integer | Ja | Key-Generation, ab der diese Aenderung wirksam ist |
 | `reason` | String | Nein | Optionale menschenlesbare Begruendung |
 
-Empfaenger MÜSSEN `member-update` gegen den naechsten Space-Sync verifizieren. Wenn die lokale CRDT-Mitgliederliste der Nachricht widerspricht, gewinnt das signierte und synchronisierte Space-Dokument. `member-update` allein DARF keine dauerhafte Membership-State-Aenderung erzwingen.
+Empfaenger MÜSSEN `member-update` gegen den naechsten Space-Sync verifizieren. Die kanonische Mitgliederliste bleibt das signierte und synchronisierte Space-Dokument. `member-update` allein DARF keine dauerhafte Membership-State-Aenderung erzwingen.
 
 ## Neue Admins hinzufügen
 
@@ -222,6 +219,12 @@ Alte Daten bleiben mit alten Space Content Keys lesbar. Rotation schuetzt nur zu
 - Der Broker MUSS nach erfolgreicher `space-rotate` Verarbeitung alte Capabilities ablehnen (`CAPABILITY_GENERATION_STALE`).
 - Clients MUESSEN neue Log-Eintraege nach Rotation mit der neuen `keyGeneration` schreiben.
 - Clients MUESSEN alte Log-Eintraege weiter mit der jeweils im Log-Eintrag angegebenen historischen `keyGeneration` entschluesseln.
+
+Clients MUESSEN Key-Rotations anhand ihrer lokal bekannten Space-Key-Generation anwenden:
+
+- Wenn `generation` der lokal bekannten Generation plus eins entspricht, DARF die Rotation angewendet werden.
+- Wenn `generation` kleiner oder gleich der lokal bekannten Generation ist, MUSS die Rotation als doppelt oder veraltet ignoriert werden.
+- Wenn `generation` groesser als die lokal bekannte Generation plus eins ist, MUSS der Client die Rotation als zukuenftige Rotation behandeln. Er DARF sie puffern, MUSS fehlende Rotationen oder einen aktuellen Snapshot/Full-State nachladen und DARF die zukuenftige Rotation nicht anwenden, bevor die Luecke geschlossen ist.
 
 ## Concurrent-Verhalten
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -95,7 +95,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Personal Doc Key aus `wot/personal-doc/v1` ableiten.
 - Personal Doc mit derselben Log-Infrastruktur wie Spaces synchronisieren.
 - Space Content Keys und Capability Keys gemaess Sync 001/005 verwalten.
-- Invitee Encryption Keys ueber QR-Cache, DID-Dokument `keyAgreement` oder konsistenten Profil-Alias aufloesen und fehlende Keys als Invite-Fehler behandeln.
+- Invitee Encryption Keys ueber QR-Cache oder DID-Dokument `keyAgreement` aufloesen und fehlende Keys als Invite-Fehler behandeln.
 - `space-invite`, `member-update` und `key-rotation` Inbox-Nachrichten erzeugen, parsen und gegen die Space-Membership-Regeln pruefen.
 - Key-Rotation bei Member-Entfernung verarbeiten.
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -61,6 +61,7 @@ Eine Implementierung ist `wot-trust@0.1`-konform, wenn sie zusaetzlich `wot-iden
 - QR-Challenge-Felder gemaess Trust 002 parsen.
 - Verification-Attestations als VC-JWS erzeugen und verifizieren.
 - Nonces gegen aktive Challenges und Nonce-History pruefen.
+- Online-In-Person-Verifikationen nur bei aktiver, noch nicht verbrauchter Challenge-Nonce akzeptieren.
 
 ## `wot-sync@0.1`
 
@@ -94,6 +95,8 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Personal Doc Key aus `wot/personal-doc/v1` ableiten.
 - Personal Doc mit derselben Log-Infrastruktur wie Spaces synchronisieren.
 - Space Content Keys und Capability Keys gemaess Sync 001/005 verwalten.
+- Invitee Encryption Keys ueber QR-Cache, DID-Dokument `keyAgreement` oder konsistenten Profil-Alias aufloesen und fehlende Keys als Invite-Fehler behandeln.
+- `space-invite`, `member-update` und `key-rotation` Inbox-Nachrichten erzeugen, parsen und gegen die Space-Membership-Regeln pruefen.
 - Key-Rotation bei Member-Entfernung verarbeiten.
 
 ## `wot-device-delegation@0.1` (geplant)

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -52,6 +52,7 @@
         "schemas/didcomm-plaintext-message.schema.json",
         "schemas/key-rotation.schema.json",
         "schemas/log-entry-payload.schema.json",
+        "schemas/member-update.schema.json",
         "schemas/profile-service-response.schema.json",
         "schemas/space-invite.schema.json"
       ],
@@ -64,6 +65,7 @@
             "log_payload_encryption",
             "log_entry_jws",
             "space_capability_jws",
+            "space_membership_messages",
             "admin_key_derivation",
             "personal_doc"
           ]

--- a/schemas/README.md
+++ b/schemas/README.md
@@ -25,6 +25,7 @@ Status: initialer Draft. Die Schemas decken die in den Spec-Dokumenten beschrieb
 | `profile-service-response.schema.json` | Sync 004 | Profil-Service Antwort mit DID-Dokument |
 | `space-invite.schema.json` | Sync 005 | Space-Einladung ueber Inbox |
 | `key-rotation.schema.json` | Sync 005 | Key-Rotation Nachricht |
+| `member-update.schema.json` | Sync 005 | Mitgliedschafts-Aenderung ueber Inbox |
 | `trust-list-delta.schema.json` | H03 | HMC Trust-List-Gossip Nachricht |
 
 ## Regeln

--- a/schemas/examples/invalid/member-update.json
+++ b/schemas/examples/invalid/member-update.json
@@ -3,13 +3,12 @@
   "typ": "application/didcomm-plain+json",
   "type": "https://web-of-trust.de/protocols/member-update/1.0",
   "from": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
-  "to": [],
+  "to": ["did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"],
   "created_time": 1776945600,
   "body": {
-    "spaceId": "not-a-uuid",
+    "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
     "action": "joined",
-    "memberDid": "not-a-did",
-    "members": ["did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"],
-    "effectiveKeyGeneration": -1
+    "memberDid": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+    "effectiveKeyGeneration": 3
   }
 }

--- a/schemas/examples/invalid/member-update.json
+++ b/schemas/examples/invalid/member-update.json
@@ -1,0 +1,15 @@
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "typ": "application/didcomm-plain+json",
+  "type": "https://web-of-trust.de/protocols/member-update/1.0",
+  "from": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+  "to": [],
+  "created_time": 1776945600,
+  "body": {
+    "spaceId": "not-a-uuid",
+    "action": "joined",
+    "memberDid": "not-a-did",
+    "members": ["did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"],
+    "effectiveKeyGeneration": -1
+  }
+}

--- a/schemas/examples/valid/member-update.json
+++ b/schemas/examples/valid/member-update.json
@@ -1,0 +1,18 @@
+{
+  "id": "550e8400-e29b-41d4-a716-446655440000",
+  "typ": "application/didcomm-plain+json",
+  "type": "https://web-of-trust.de/protocols/member-update/1.0",
+  "from": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+  "to": ["did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"],
+  "created_time": 1776945600,
+  "body": {
+    "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+    "action": "added",
+    "memberDid": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+    "members": [
+      "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+      "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
+    ],
+    "effectiveKeyGeneration": 3
+  }
+}

--- a/schemas/examples/valid/member-update.json
+++ b/schemas/examples/valid/member-update.json
@@ -9,10 +9,6 @@
     "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
     "action": "added",
     "memberDid": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-    "members": [
-      "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
-      "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH"
-    ],
     "effectiveKeyGeneration": 3
   }
 }

--- a/schemas/examples/valid/profile-service-response.json
+++ b/schemas/examples/valid/profile-service-response.json
@@ -24,7 +24,6 @@
   },
   "profile": {
     "name": "Alice",
-    "encryptionPublicKey": "yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ",
     "protocols": ["https://web-of-trust.de/protocols/log-entry/1.0"]
   },
   "updatedAt": "2026-04-17T10:00:00Z"

--- a/schemas/examples/valid/profile-service-response.json
+++ b/schemas/examples/valid/profile-service-response.json
@@ -1,9 +1,30 @@
 {
   "did": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
   "version": 1,
-  "didDocument": {},
+  "didDocument": {
+    "id": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+    "verificationMethod": [
+      {
+        "id": "#sig-0",
+        "type": "Ed25519VerificationKey2020",
+        "controller": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+        "publicKeyMultibase": "z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"
+      }
+    ],
+    "authentication": ["#sig-0"],
+    "assertionMethod": ["#sig-0"],
+    "keyAgreement": [
+      {
+        "id": "#enc-0",
+        "type": "X25519KeyAgreementKey2020",
+        "controller": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+        "publicKeyMultibase": "z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV"
+      }
+    ]
+  },
   "profile": {
     "name": "Alice",
+    "encryptionPublicKey": "yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ",
     "protocols": ["https://web-of-trust.de/protocols/log-entry/1.0"]
   },
   "updatedAt": "2026-04-17T10:00:00Z"

--- a/schemas/member-update.schema.json
+++ b/schemas/member-update.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://web-of-trust.de/schemas/member-update.schema.json",
+  "title": "WoT Member Update Message",
+  "type": "object",
+  "required": ["id", "typ", "type", "from", "to", "created_time", "body"],
+  "additionalProperties": true,
+  "properties": {
+    "id": { "type": "string", "format": "uuid" },
+    "typ": { "const": "application/didcomm-plain+json" },
+    "type": { "const": "https://web-of-trust.de/protocols/member-update/1.0" },
+    "from": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
+    "to": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" }
+    },
+    "created_time": { "type": "integer", "minimum": 0 },
+    "thid": { "type": "string", "format": "uuid" },
+    "pthid": { "type": "string", "format": "uuid" },
+    "body": {
+      "type": "object",
+      "required": ["spaceId", "action", "memberDid", "members", "effectiveKeyGeneration"],
+      "additionalProperties": false,
+      "properties": {
+        "spaceId": { "type": "string", "format": "uuid" },
+        "action": { "enum": ["added", "removed"] },
+        "memberDid": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
+        "members": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" }
+        },
+        "effectiveKeyGeneration": { "type": "integer", "minimum": 0 },
+        "reason": { "type": "string" }
+      }
+    }
+  }
+}

--- a/schemas/member-update.schema.json
+++ b/schemas/member-update.schema.json
@@ -20,16 +20,12 @@
     "pthid": { "type": "string", "format": "uuid" },
     "body": {
       "type": "object",
-      "required": ["spaceId", "action", "memberDid", "members", "effectiveKeyGeneration"],
+      "required": ["spaceId", "action", "memberDid", "effectiveKeyGeneration"],
       "additionalProperties": false,
       "properties": {
         "spaceId": { "type": "string", "format": "uuid" },
         "action": { "enum": ["added", "removed"] },
         "memberDid": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
-        "members": {
-          "type": "array",
-          "items": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" }
-        },
         "effectiveKeyGeneration": { "type": "integer", "minimum": 0 },
         "reason": { "type": "string" }
       }

--- a/schemas/profile-service-response.schema.json
+++ b/schemas/profile-service-response.schema.json
@@ -17,6 +17,7 @@
         "name": { "type": "string", "minLength": 1 },
         "bio": { "type": "string" },
         "avatar": { "type": "string" },
+        "encryptionPublicKey": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
         "protocols": { "type": "array", "items": { "type": "string", "format": "uri" } }
       }
     },

--- a/schemas/profile-service-response.schema.json
+++ b/schemas/profile-service-response.schema.json
@@ -13,11 +13,11 @@
       "type": "object",
       "required": ["name"],
       "additionalProperties": true,
+      "not": { "required": ["encryptionPublicKey"] },
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "bio": { "type": "string" },
         "avatar": { "type": "string" },
-        "encryptionPublicKey": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
         "protocols": { "type": "array", "items": { "type": "string", "format": "uri" } }
       }
     },

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -137,6 +137,37 @@
     },
     "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6IndvdDpzcGFjZTo3ZjNhMmIxMC00YzVkLTRlNmYtOGE3Yi05YzBkMWUyZjNhNGIjY2FwLTMiLCJ0eXAiOiJ3b3QtY2FwYWJpbGl0eStqd3QifQ.eyJhdWRpZW5jZSI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwiZ2VuZXJhdGlvbiI6MywiaXNzdWVkQXQiOiIyMDI2LTA0LTIyVDEwOjAwOjAwWiIsInBlcm1pc3Npb25zIjpbInJlYWQiLCJ3cml0ZSJdLCJzcGFjZUlkIjoiN2YzYTJiMTAtNGM1ZC00ZTZmLThhN2ItOWMwZDFlMmYzYTRiIiwidHlwZSI6ImNhcGFiaWxpdHkiLCJ2YWxpZFVudGlsIjoiMjAyNi0xMC0yMlQxMDowMDowMFoifQ.lqBuMxntI15vmJCnT9UTavTQqM_sxbL4fcrt_n_cSakXE4fy-EFvnXWAngNq5uFYqPbX_r8W-TE16Md97pfWAQ"
   },
+  "space_membership_messages": {
+    "invite_key_discovery": {
+      "canonical_key_agreement_id": "#enc-0",
+      "x25519_public_b64": "yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ",
+      "x25519_public_multibase": "z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV",
+      "profile_encryption_public_key_alias_must_match": true
+    },
+    "space_invite_body": {
+      "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+      "brokerUrls": ["wss://broker.example.com"],
+      "currentKeyGeneration": 3,
+      "spaceContentKeys": [{ "generation": 3, "key": "abc_123" }],
+      "spaceCapabilitySigningKey": "def_456",
+      "adminDids": ["did:key:z6MkvLMiE11z8wXjNScxqjcMJHNfNyc8XqDT4aGzry4pFTTd"],
+      "capability": "aaa.bbb.ccc"
+    },
+    "member_update_body": {
+      "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+      "action": "removed",
+      "memberDid": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+      "members": ["did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"],
+      "effectiveKeyGeneration": 4
+    },
+    "key_rotation_body": {
+      "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+      "generation": 4,
+      "spaceContentKey": "abc_123",
+      "spaceCapabilitySigningKey": "def_456",
+      "capability": "aaa.bbb.ccc"
+    }
+  },
   "admin_key_derivation": {
     "space_id": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
     "hkdf_info": "wot/space-admin/7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b/v1",

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -141,8 +141,7 @@
     "invite_key_discovery": {
       "canonical_key_agreement_id": "#enc-0",
       "x25519_public_b64": "yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ",
-      "x25519_public_multibase": "z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV",
-      "profile_encryption_public_key_alias_must_match": true
+      "x25519_public_multibase": "z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV"
     },
     "space_invite_body": {
       "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
@@ -157,7 +156,6 @@
       "spaceId": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
       "action": "removed",
       "memberDid": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
-      "members": ["did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"],
       "effectiveKeyGeneration": 4
     },
     "key_rotation_body": {

--- a/test-vectors/phase-1-interop.md
+++ b/test-vectors/phase-1-interop.md
@@ -132,7 +132,35 @@ JWS Compact:
 eyJhbGciOiJFZERTQSIsImtpZCI6IndvdDpzcGFjZTo3ZjNhMmIxMC00YzVkLTRlNmYtOGE3Yi05YzBkMWUyZjNhNGIjY2FwLTMiLCJ0eXAiOiJ3b3QtY2FwYWJpbGl0eStqd3QifQ.eyJhdWRpZW5jZSI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwiZ2VuZXJhdGlvbiI6MywiaXNzdWVkQXQiOiIyMDI2LTA0LTIyVDEwOjAwOjAwWiIsInBlcm1pc3Npb25zIjpbInJlYWQiLCJ3cml0ZSJdLCJzcGFjZUlkIjoiN2YzYTJiMTAtNGM1ZC00ZTZmLThhN2ItOWMwZDFlMmYzYTRiIiwidHlwZSI6ImNhcGFiaWxpdHkiLCJ2YWxpZFVudGlsIjoiMjAyNi0xMC0yMlQxMDowMDowMFoifQ.lqBuMxntI15vmJCnT9UTavTQqM_sxbL4fcrt_n_cSakXE4fy-EFvnXWAngNq5uFYqPbX_r8W-TE16Md97pfWAQ
 ```
 
-## 8. Admin-Key-Ableitung (Sync 001/005)
+## 8. Space Membership Messages (Sync 005)
+
+Diese Vektoren fixieren die Feldnamen fuer Space-Invite, Member-Update, Key-Rotation und Invite-Key-Discovery. Die Beispiel-Keys `abc_123` / `def_456` sind Platzhalter fuer Base64URL-kodiertes Key-Material; kryptographische Gueltigkeit der Capability wird im Space-Capability-Vektor separat geprueft.
+
+Invite-Key-Discovery:
+
+```json
+{"canonical_key_agreement_id":"#enc-0","profile_encryption_public_key_alias_must_match":true,"x25519_public_b64":"yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ","x25519_public_multibase":"z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV"}
+```
+
+Space-Invite Body:
+
+```json
+{"adminDids":["did:key:z6MkvLMiE11z8wXjNScxqjcMJHNfNyc8XqDT4aGzry4pFTTd"],"brokerUrls":["wss://broker.example.com"],"capability":"aaa.bbb.ccc","currentKeyGeneration":3,"spaceCapabilitySigningKey":"def_456","spaceContentKeys":[{"generation":3,"key":"abc_123"}],"spaceId":"7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"}
+```
+
+Member-Update Body:
+
+```json
+{"action":"removed","effectiveKeyGeneration":4,"memberDid":"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH","members":["did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"],"spaceId":"7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"}
+```
+
+Key-Rotation Body:
+
+```json
+{"capability":"aaa.bbb.ccc","generation":4,"spaceCapabilitySigningKey":"def_456","spaceContentKey":"abc_123","spaceId":"7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"}
+```
+
+## 9. Admin-Key-Ableitung (Sync 001/005)
 
 ```
 spaceId: 7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b
@@ -142,7 +170,7 @@ Admin Public Key: ebf654f331fdbf131ca46ce2f28b269ceee064244e521b557a3e919bffe32c
 Admin DID: did:key:z6MkvLMiE11z8wXjNScxqjcMJHNfNyc8XqDT4aGzry4pFTTd
 ```
 
-## 9. Personal-Doc-Key und Document-ID (Sync 006)
+## 10. Personal-Doc-Key und Document-ID (Sync 006)
 
 ```
 HKDF Info: wot/personal-doc/v1
@@ -150,7 +178,7 @@ Personal Doc Key: ed3b3cbec944063041a15cf14be4c2aecd87ec30f2085cd9f2f82333cfcd43
 Document-ID: ed3b3cbe-c944-0630-41a1-5cf14be4c2ae
 ```
 
-## 10. SD-JWT VC Trust List (H01/H03)
+## 11. SD-JWT VC Trust List (H01/H03)
 
 Minimaler Draft-Vektor fuer eine Trust-List mit einem selectively-disclosable Eintrag.
 

--- a/test-vectors/phase-1-interop.md
+++ b/test-vectors/phase-1-interop.md
@@ -139,7 +139,7 @@ Diese Vektoren fixieren die Feldnamen fuer Space-Invite, Member-Update, Key-Rota
 Invite-Key-Discovery:
 
 ```json
-{"canonical_key_agreement_id":"#enc-0","profile_encryption_public_key_alias_must_match":true,"x25519_public_b64":"yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ","x25519_public_multibase":"z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV"}
+{"canonical_key_agreement_id":"#enc-0","x25519_public_b64":"yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ","x25519_public_multibase":"z6LSqA7sbKGK3WVHP9SBcmv9ikp19iDNb1P5Q315kRPQrcTV"}
 ```
 
 Space-Invite Body:
@@ -151,7 +151,7 @@ Space-Invite Body:
 Member-Update Body:
 
 ```json
-{"action":"removed","effectiveKeyGeneration":4,"memberDid":"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH","members":["did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a"],"spaceId":"7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"}
+{"action":"removed","effectiveKeyGeneration":4,"memberDid":"did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH","spaceId":"7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"}
 ```
 
 Key-Rotation Body:


### PR DESCRIPTION
## Summary
- Norms invite key discovery, member-update messages, key-rotation invariants, and snapshot/full-state rules for sync spaces.
- Adds the member-update schema, examples, conformance manifest entry, and phase-1 membership vectors.
- Clarifies that online in-person verification requires an active unused challenge nonce and that profile encryption key aliases must match DID document keyAgreement.

## Validation
- npm run validate