### PR TITLE
Sync-Flow-State-Machine spezifizieren

### DIFF
--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -164,6 +164,7 @@ Die folgenden Flows definieren die Reihenfolge der Operationen fuer `wot-sync@0.
 ### Gemeinsame Regeln
 
 - Dauerhafter Zustand MUSS aus Log-Eintraegen, Personal-Doc-Eintraegen, Space-Metadaten, Group Keys und durabel gepufferten Inbox-Nachrichten rekonstruierbar sein.
+- Durabel gepufferte Pending-Zustaende, z.B. Pending-Inbox, `blocked-by-key` oder `future-rotation`, sind lokaler crash-sicherer State. Der konkrete Speicherort ist implementationsspezifisch, MUSS aber App-Neustarts ueberleben und MUSS alle Metadaten enthalten, die fuer erneute Pruefung und Anwendung noetig sind, mindestens Message-/Log-Entry-ID, betroffene `docId`, Abhaengigkeitsart und erwartete `keyGeneration`.
 - Ein Client DARF eine Inbox-Nachricht erst ACKen, wenn er sie entweder erfolgreich angewendet hat oder sie inklusive aller Abhaengigkeits-Metadaten dauerhaft gepuffert hat. Nach einem ACK darf der Broker die Nachricht fuer genau dieses Device loeschen (siehe [Sync 003 ACK](003-transport-und-broker.md#ack10--empfangsbestätigung)).
 - Ein Client DARF einen empfangenen Log-Eintrag nicht verwerfen, nur weil ihm der passende `keyGeneration`-Key fehlt. Er MUSS den Eintrag speichern oder erneut abrufbar lassen und den Eintrag als `blocked-by-key` behandeln.
 - Push- und Inbox-Nachrichten sind Wecksignale oder Key-/Control-Messages. Sie ersetzen keinen Log-Catch-Up fuer das betroffene Dokument.
@@ -171,16 +172,17 @@ Die folgenden Flows definieren die Reihenfolge der Operationen fuer `wot-sync@0.
 
 ### App-Start und Reconnect
 
-Bei App-Start und bei jedem Broker-Reconnect MUSS ein Client fuer jedes aktive Dokument folgenden Ablauf ausfuehren:
+Bei App-Start und bei jedem Broker-Reconnect MUSS ein Client fuer das Personal Doc und danach fuer alle bekannten aktiven Space-Dokumente folgenden Ablauf ausfuehren:
 
 1. Lokalen persistenten Zustand laden: Device-ID, bekannte Heads pro `(docId, deviceId)`, lokale Log-Eintraege, durabel gepufferte Inbox-Nachrichten, Personal Doc, Space-Metadaten und Group Keys.
 2. Beim Broker authentisieren, inklusive `did` und `deviceId` (siehe [Sync 003 Authentisierung](003-transport-und-broker.md#authentisierung)).
-3. Pro aktivem Dokument `broker_seq` und `local_seq` fuer die eigene `(deviceId, docId)`-Kombination vergleichen, bevor neue Eintraege an den Broker publiziert werden. Bei `broker_seq > local_seq` gilt die Restore-/Clone-Regel aus [seq-Konsistenz](#seq-konsistenz-muss).
+3. Fuer das Personal Doc `broker_seq` und `local_seq` fuer die eigene `(deviceId, docId)`-Kombination vergleichen, bevor neue Personal-Doc-Eintraege an den Broker publiziert werden. Bei `broker_seq > local_seq` gilt die Restore-/Clone-Regel aus [seq-Konsistenz](#seq-konsistenz-muss).
 4. Die eigene Device-Inbox drainen. Inbox-Nachrichten duerfen in beliebiger Reihenfolge empfangen werden, MUESSEN aber gemaess [Inbox-Verarbeitung](#inbox-verarbeitung-und-ack) verarbeitet, angewendet oder durabel gepuffert werden.
 5. Das Personal Doc per `sync-request` synchronisieren, bevor Space-Dokumente verarbeitet werden, die neue Space-Mitgliedschaften oder Group Keys benoetigen koennen.
-6. Fuer jedes bekannte Space-Dokument einen `sync-request` mit den lokal bekannten Heads senden.
-7. Empfangene `sync-response`-Eintraege verifizieren, lokal persistieren, nach `keyGeneration` entschluesseln und in den CRDT mergen. Eintraege mit fehlenden Keys werden als `blocked-by-key` gespeichert und spaeter erneut verarbeitet.
-8. Erst nach Personal-Doc-Catch-Up, Inbox-Verarbeitung und Space-Catch-Up SOLL die UI den Sync-Zustand als aktuell anzeigen. Eine Implementierung DARF vorher lokale Daten anzeigen, MUSS diese aber als potentiell veraltet behandeln.
+6. Nach abgeschlossenem Personal-Doc-Catch-Up die aktiven Space-Dokumente aus aktualisiertem Personal Doc, lokal persistenten Space-Metadaten und durabel gepufferten Abhaengigkeiten bestimmen.
+7. Fuer jedes bekannte Space-Dokument `broker_seq` und `local_seq` fuer die eigene `(deviceId, docId)`-Kombination vergleichen, bevor neue Space-Eintraege publiziert werden, und danach einen `sync-request` mit den lokal bekannten Heads senden.
+8. Empfangene `sync-response`-Eintraege verifizieren, lokal persistieren, nach `keyGeneration` entschluesseln und in den CRDT mergen. Eintraege mit fehlenden Keys werden als `blocked-by-key` gespeichert und spaeter erneut verarbeitet.
+9. Erst nach Personal-Doc-Catch-Up, Inbox-Verarbeitung und Space-Catch-Up SOLL die UI den Sync-Zustand als aktuell anzeigen. Eine Implementierung DARF vorher lokale Daten anzeigen, MUSS diese aber als potentiell veraltet behandeln.
 
 Wenn mehrere Broker oder P2P-Quellen verfuegbar sind, SOLLTE der Client diese Runden gegen mehrere Quellen ausfuehren und Heads vergleichen (siehe [Censorship- und Split-Brain-Detection](#censorship--und-split-brain-detection)).
 
@@ -227,6 +229,8 @@ Key-Rotation ist eine Abhaengigkeit fuer alle spaeteren Space-Log-Eintraege. Cli
 - Empfaengt ein Client eine `key-rotation` mit `generation > localGeneration + 1`, MUSS er sie als `future-rotation` durabel puffern. Er DARF sie nicht anwenden, bevor die Luecke geschlossen ist. Er MUSS fehlende Rotationen, Personal-Doc-Keys oder einen aktuellen Full-State/Log-Catch-Up anfordern.
 - Empfaengt ein Client einen Log-Eintrag mit unbekannter `keyGeneration`, MUSS er den Eintrag als `blocked-by-key` speichern oder erneut abrufbar lassen und Key-/Personal-Doc-Catch-Up anfordern. Er DARF den Eintrag nicht als verarbeitet markieren.
 - Sobald eine fehlende Generation verfuegbar wird, MUSS der Client alle gepufferten `future-rotation`-Nachrichten und `blocked-by-key`-Log-Eintraege in aufsteigender Generation erneut pruefen.
+
+`Anfordern` von fehlenden Rotationen oder Keys bedeutet in `wot-sync@0.1`, dass ein Client die bestehenden Sync-Quellen erneut nutzt: eigene Device-Inbox drainen, Personal Doc per `sync-request` aufholen, fuer das betroffene Space-Dokument einen `sync-request` senden und, falls implementiert, einen autorisierten Snapshot oder Full-State abrufen. Ein separates generisches `key-request` Nachrichtenformat ist in `wot-sync@0.1` nicht normiert. Solange die fehlende Generation danach nicht verfuegbar ist, MUSS der Client die betroffenen `future-rotation`- und `blocked-by-key`-Eintraege durabel gepuffert lassen und bei App-Start, Reconnect oder neuem Wecksignal erneut aufloesen.
 
 ### Snapshot- und Full-State-Optimierungen
 

--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -157,6 +157,87 @@ Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Syn
 
 Das Log-Protokoll unterstützt Live-Sync und Catch-Up. Peers tauschen Heads pro `(docId, deviceId)` aus und senden fehlende Einträge. Push-Notifications sind nur ein Wecksignal; der Client holt fehlende Einträge danach über normalen Catch-Up (siehe [Sync 003](003-transport-und-broker.md#push-notifications)).
 
+## Normative Sync-Flows
+
+Die folgenden Flows definieren die Reihenfolge der Operationen fuer `wot-sync@0.1`. Implementierungen duerfen einzelne Schritte parallelisieren, MUESSEN aber dieselben Abhaengigkeiten einhalten und MUESSEN jeden Flow idempotent implementieren. Mehrfach empfangene Nachrichten, mehrfach publizierte Log-Eintraege und wiederholte `sync-request`-Runden duerfen keinen anderen Endzustand erzeugen als eine einmalige Verarbeitung.
+
+### Gemeinsame Regeln
+
+- Dauerhafter Zustand MUSS aus Log-Eintraegen, Personal-Doc-Eintraegen, Space-Metadaten, Group Keys und durabel gepufferten Inbox-Nachrichten rekonstruierbar sein.
+- Ein Client DARF eine Inbox-Nachricht erst ACKen, wenn er sie entweder erfolgreich angewendet hat oder sie inklusive aller Abhaengigkeits-Metadaten dauerhaft gepuffert hat. Nach einem ACK darf der Broker die Nachricht fuer genau dieses Device loeschen (siehe [Sync 003 ACK](003-transport-und-broker.md#ack10--empfangsbestätigung)).
+- Ein Client DARF einen empfangenen Log-Eintrag nicht verwerfen, nur weil ihm der passende `keyGeneration`-Key fehlt. Er MUSS den Eintrag speichern oder erneut abrufbar lassen und den Eintrag als `blocked-by-key` behandeln.
+- Push- und Inbox-Nachrichten sind Wecksignale oder Key-/Control-Messages. Sie ersetzen keinen Log-Catch-Up fuer das betroffene Dokument.
+- Snapshots, Full-State-Nachrichten und Vault-Backups sind Optimierungen. Sie duerfen keinen bekannten gueltigen Log-Eintrag zurueckrollen und duerfen eine fehlende Log-Sync-Runde nicht ersetzen.
+
+### App-Start und Reconnect
+
+Bei App-Start und bei jedem Broker-Reconnect MUSS ein Client fuer jedes aktive Dokument folgenden Ablauf ausfuehren:
+
+1. Lokalen persistenten Zustand laden: Device-ID, bekannte Heads pro `(docId, deviceId)`, lokale Log-Eintraege, durabel gepufferte Inbox-Nachrichten, Personal Doc, Space-Metadaten und Group Keys.
+2. Beim Broker authentisieren, inklusive `did` und `deviceId` (siehe [Sync 003 Authentisierung](003-transport-und-broker.md#authentisierung)).
+3. Pro aktivem Dokument `broker_seq` und `local_seq` fuer die eigene `(deviceId, docId)`-Kombination vergleichen, bevor neue Eintraege an den Broker publiziert werden. Bei `broker_seq > local_seq` gilt die Restore-/Clone-Regel aus [seq-Konsistenz](#seq-konsistenz-muss).
+4. Die eigene Device-Inbox drainen. Inbox-Nachrichten duerfen in beliebiger Reihenfolge empfangen werden, MUESSEN aber gemaess [Inbox-Verarbeitung](#inbox-verarbeitung-und-ack) verarbeitet, angewendet oder durabel gepuffert werden.
+5. Das Personal Doc per `sync-request` synchronisieren, bevor Space-Dokumente verarbeitet werden, die neue Space-Mitgliedschaften oder Group Keys benoetigen koennen.
+6. Fuer jedes bekannte Space-Dokument einen `sync-request` mit den lokal bekannten Heads senden.
+7. Empfangene `sync-response`-Eintraege verifizieren, lokal persistieren, nach `keyGeneration` entschluesseln und in den CRDT mergen. Eintraege mit fehlenden Keys werden als `blocked-by-key` gespeichert und spaeter erneut verarbeitet.
+8. Erst nach Personal-Doc-Catch-Up, Inbox-Verarbeitung und Space-Catch-Up SOLL die UI den Sync-Zustand als aktuell anzeigen. Eine Implementierung DARF vorher lokale Daten anzeigen, MUSS diese aber als potentiell veraltet behandeln.
+
+Wenn mehrere Broker oder P2P-Quellen verfuegbar sind, SOLLTE der Client diese Runden gegen mehrere Quellen ausfuehren und Heads vergleichen (siehe [Censorship- und Split-Brain-Detection](#censorship--und-split-brain-detection)).
+
+### Lokaler Schreibvorgang
+
+Bei jedem lokalen Schreibvorgang in ein Personal Doc oder Space-Dokument MUSS der Client:
+
+1. Den naechsten `seq`-Wert atomar aus dem persistenten Log fuer `(deviceId, docId)` reservieren. Wenn der Broker erreichbar ist, MUSS vorher ein Broker-Head-Abgleich stattfinden; wenn der Client offline ist, MUSS spaetestens vor der ersten Publikation nach Reconnect der Broker-Head-Abgleich stattfinden.
+2. Den CRDT-Update-Payload mit dem aktuell gueltigen Key und der aktuell gueltigen `keyGeneration` verschluesseln.
+3. Einen Log-Entry-JWS mit `seq`, `deviceId`, `docId`, `authorKid`, `keyGeneration`, `data` und `timestamp` erzeugen und signieren.
+4. Den Log-Eintrag lokal persistieren, bevor er an Broker oder Peers uebermittelt wird.
+5. Den Log-Eintrag an alle relevanten Broker/Peers publizieren. Fehler bei der Uebermittlung MUESSEN als retrybarer Outbox-Zustand behandelt werden; eine erneute Publikation desselben Log-Eintrags MUSS idempotent sein.
+6. Keine Inbox-ACK-Semantik fuer Log-Eintraege verwenden. Fehlende Log-Eintraege werden ueber Heads und `sync-request` erkannt.
+
+### Inbox-Verarbeitung und ACK
+
+Inbox-Nachrichten sind direkte Nachrichten wie Attestations, Verifications, Space-Einladungen, `member-update` und `key-rotation`. Fuer jede empfangene Inbox-Nachricht MUSS der Client:
+
+1. ECIES entschluesseln, wenn die Nachricht verschluesselt ist.
+2. Das innere JWS oder das normative persistente Objekt verifizieren. Envelope-Felder allein duerfen nicht als Autoritaetsanker verwendet werden (siehe [Sync 003 Autoritaetsgrenze](003-transport-und-broker.md#autoritätsgrenze-muss)).
+3. Replay-Schutz ueber Message-ID-History anwenden.
+4. Die resultierende lokale Aenderung anwenden oder die Nachricht durabel in einer Pending-Inbox speichern, wenn Abhaengigkeiten fehlen.
+5. Falls die Nachricht ein Dokument betrifft, danach einen `sync-request` fuer dieses Dokument ausloesen oder vormerken. Ein `space-invite` fuehrt zu Space-Catch-Up; eine `key-rotation` fuehrt zu erneuter Verarbeitung blockierter Log-Eintraege fuer diese `keyGeneration`.
+6. Erst dann ACKen, wenn Schritt 4 dauerhaft abgeschlossen ist. Bei einem Prozess-Crash nach ACK MUSS der Client ohne erneute Broker-Zustellung fortfahren koennen.
+
+Wenn eine Inbox-Nachricht ungueltig ist (falsche Signatur, falscher Empfaenger, Replay, abgelaufen), MUSS der Client sie verwerfen und DARF sie ACKen, damit der Broker sie fuer dieses Device nicht erneut liefert. Der Client SOLLTE lokale Audit-/Debug-Informationen speichern, aber keinen autoritativen State aendern.
+
+### Space-Invite-Annahme
+
+Bei Annahme einer `space-invite` MUSS der Client:
+
+1. Einladung entschluesseln und inneres JWS, Empfaenger-DID, Capability und `currentKeyGeneration` pruefen.
+2. Space Content Keys, Space Capability Signing Key, Capability, Broker-URLs und Space-Metadaten im Personal Doc oder lokalem aequivalentem Zustand persistieren.
+3. Danach den Invite ACKen.
+4. Einen `sync-request` fuer das Space-Dokument mit leeren oder lokalen Heads senden.
+5. Empfangene Log-Eintraege gemaess normalem Space-Catch-Up verarbeiten. Wenn die Einladung nicht alle historischen Keys enthaelt, MUSS der erste verarbeitbare Snapshot oder Log-Eintrag mit `currentKeyGeneration` erreichbar sein; sonst bleibt der Space `blocked-by-key`.
+
+### Key-Rotation und Generation-Gaps
+
+Key-Rotation ist eine Abhaengigkeit fuer alle spaeteren Space-Log-Eintraege. Clients MUESSEN folgende Regeln anwenden:
+
+- Empfaengt ein Client eine `key-rotation` mit `generation = localGeneration + 1`, MUSS er den neuen Content Key und die neue Capability durabel speichern, blockierte Log-Eintraege dieser Generation erneut verarbeiten und einen `sync-request` fuer das Space-Dokument ausloesen.
+- Empfaengt ein Client eine `key-rotation` mit `generation <= localGeneration`, MUSS er sie als doppelt oder veraltet behandeln. Er DARF sie ACKen, nachdem Replay- und Signaturpruefung abgeschlossen sind.
+- Empfaengt ein Client eine `key-rotation` mit `generation > localGeneration + 1`, MUSS er sie als `future-rotation` durabel puffern. Er DARF sie nicht anwenden, bevor die Luecke geschlossen ist. Er MUSS fehlende Rotationen, Personal-Doc-Keys oder einen aktuellen Full-State/Log-Catch-Up anfordern.
+- Empfaengt ein Client einen Log-Eintrag mit unbekannter `keyGeneration`, MUSS er den Eintrag als `blocked-by-key` speichern oder erneut abrufbar lassen und Key-/Personal-Doc-Catch-Up anfordern. Er DARF den Eintrag nicht als verarbeitet markieren.
+- Sobald eine fehlende Generation verfuegbar wird, MUSS der Client alle gepufferten `future-rotation`-Nachrichten und `blocked-by-key`-Log-Eintraege in aufsteigender Generation erneut pruefen.
+
+### Snapshot- und Full-State-Optimierungen
+
+Snapshots und Full-State-Nachrichten duerfen verwendet werden, um lange Catch-Up-Runden zu beschleunigen. Sie MUESSEN aber wie folgt eingeordnet werden:
+
+1. Ein Snapshot MUSS mindestens `docId`, `keyGeneration` und eine Abdeckung der enthaltenen Log-Heads (`heads` oder aequivalente Metadaten) besitzen, wenn er als Catch-Up-Optimierung verwendet wird.
+2. Kann eine Implementierung die Abdeckung nicht bestimmen, DARF sie den Snapshot nur als CRDT-Merge-Hilfe verwenden und MUSS danach trotzdem eine normale `sync-request`-Runde ausfuehren.
+3. Ein Snapshot mit unbekannter oder zukuenftiger `keyGeneration` wird wie ein blockierter Log-Eintrag behandelt: puffern oder erneut abrufen, fehlende Keys anfordern, nicht als verarbeitet markieren.
+4. Ein Snapshot DARF keine lokal bekannten gueltigen Log-Eintraege loeschen oder ueberschreiben. Der CRDT-Merge bleibt autoritativ fuer Konvergenz.
+5. Zeitbasierte Retry-Mechanismen duerfen als Implementierungsdetail existieren, sind aber nicht der normative Sync-Mechanismus. Normative Recovery basiert auf Heads, `sync-request`, per-Device-Inbox und Generation-Gap-Erkennung.
+
 ## Censorship- und Split-Brain-Detection
 
 Das Sync-Protokoll konvergiert, solange Peers dieselben Log-Einträge sehen. Broker oder andere Zwischenakteure können jedoch Einträge selektiv unterdrücken oder verschiedenen Peers unterschiedliche Heads zeigen.

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -134,7 +134,7 @@ Inbox-Nachrichten werden **pro Device** zwischengespeichert, nicht pro DID. Das 
 4. Wenn **alle aktiven Devices** ACKt haben, ist die Nachricht vollständig zugestellt
 5. Deaktivierte Devices werden bei der Zustellung ignoriert (und ihre Inbox-Einträge gelöscht)
 
-Bei selbstadressierten Nachrichten (`from` und `to` gehoeren zur selben DID), z.B. Cross-Device-Sync, MUSS der Broker die sendende `(did, deviceId)`-Verbindung von der Zustellung ausschliessen, sofern die Nachricht nicht explizit an genau dieses Device adressiert ist. Das sendende Device hat die lokale Aenderung bereits angewendet; ein ACK des sendenden Devices DARF niemals Inbox-Eintraege fuer andere Devices derselben DID loeschen.
+Bei selbstadressierten Inbox-Nachrichten, deren `from` und `to` zur selben DID gehoeren, z.B. Cross-Device-Sync, MUSS der Broker die sendende `(did, deviceId)`-Verbindung von der Zustellung ausschliessen. Das sendende Device hat die lokale Aenderung bereits angewendet; ein ACK des sendenden Devices DARF niemals Inbox-Eintraege fuer andere Devices derselben DID loeschen.
 
 ACKs sind pro Device scoped. Ein Broker MUSS ein ACK nur fuer die Inbox des authentifizierten `(did, deviceId)` anwenden. Ein ACK von Device A DARF keine Nachricht fuer Device B loeschen, auch wenn beide Devices dieselbe DID verwenden.
 
@@ -512,7 +512,7 @@ Der Empfänger schickt `ack` nach erfolgreichem Verarbeiten einer Inbox-Nachrich
 1. ECIES-Entschlüsselung erfolgreich, falls die Nachricht verschlüsselt war.
 2. Inneres JWS oder persistentes WoT-Objekt verifiziert.
 3. Replay-Prüfung bestanden oder die Nachricht wurde als Duplikat sicher erkannt.
-4. Resultierender lokaler State wurde angewendet oder die Nachricht wurde durabel als pending gespeichert, inklusive aller Abhängigkeits-Metadaten.
+4. Resultierender lokaler State wurde angewendet oder die Nachricht wurde gemaess [Sync 002](002-sync-protokoll.md) durabel in der **Pending-Inbox** gepuffert. `Pending` bedeutet hier: crash-sichere persistente Speicherung (nicht nur volatil im RAM) zusammen mit den fuer die spaetere Aufloesung und Anwendung erforderlichen Metadaten, mindestens `messageId` sowie Abhaengigkeits-/Missing-Dependency-Metadaten.
 
 Der Broker kann die Nachricht dann aus der Inbox **dieses authentifizierten Devices** entfernen. Er DARF sie nicht aus anderen Device-Inboxen derselben DID entfernen. Wenn der Client eine Nachricht wegen fehlender Abhaengigkeiten nur volatil im Speicher haelt, DARF er sie noch nicht ACKen.
 

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -134,6 +134,10 @@ Inbox-Nachrichten werden **pro Device** zwischengespeichert, nicht pro DID. Das 
 4. Wenn **alle aktiven Devices** ACKt haben, ist die Nachricht vollständig zugestellt
 5. Deaktivierte Devices werden bei der Zustellung ignoriert (und ihre Inbox-Einträge gelöscht)
 
+Bei selbstadressierten Nachrichten (`from` und `to` gehoeren zur selben DID), z.B. Cross-Device-Sync, MUSS der Broker die sendende `(did, deviceId)`-Verbindung von der Zustellung ausschliessen, sofern die Nachricht nicht explizit an genau dieses Device adressiert ist. Das sendende Device hat die lokale Aenderung bereits angewendet; ein ACK des sendenden Devices DARF niemals Inbox-Eintraege fuer andere Devices derselben DID loeschen.
+
+ACKs sind pro Device scoped. Ein Broker MUSS ein ACK nur fuer die Inbox des authentifizierten `(did, deviceId)` anwenden. Ein ACK von Device A DARF keine Nachricht fuer Device B loeschen, auch wenn beide Devices dieselbe DID verwenden.
+
 ### Retention und Garbage Collection
 
 - Nachrichten, die älter sind als ein definiertes TTL (z.B. 30 Tage) werden auch ohne ACK gelöscht — Implementierer dürfen das konfigurieren
@@ -503,7 +507,14 @@ Wird nur für **Inbox-Nachrichten** verwendet (nicht für sync-request/response 
 }
 ```
 
-Der Empfänger schickt `ack` nach erfolgreichem Verarbeiten (Entschlüsseln, Signatur-Verifizieren) einer Inbox-Nachricht. Der Broker kann die Nachricht dann aus der Device-Inbox entfernen.
+Der Empfänger schickt `ack` nach erfolgreichem Verarbeiten einer Inbox-Nachricht. Erfolgreich verarbeitet bedeutet:
+
+1. ECIES-Entschlüsselung erfolgreich, falls die Nachricht verschlüsselt war.
+2. Inneres JWS oder persistentes WoT-Objekt verifiziert.
+3. Replay-Prüfung bestanden oder die Nachricht wurde als Duplikat sicher erkannt.
+4. Resultierender lokaler State wurde angewendet oder die Nachricht wurde durabel als pending gespeichert, inklusive aller Abhängigkeits-Metadaten.
+
+Der Broker kann die Nachricht dann aus der Inbox **dieses authentifizierten Devices** entfernen. Er DARF sie nicht aus anderen Device-Inboxen derselben DID entfernen. Wenn der Client eine Nachricht wegen fehlender Abhaengigkeiten nur volatil im Speicher haelt, DARF er sie noch nicht ACKen.
 
 #### Fehler-Responses
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -186,6 +186,18 @@ Der Admin MUSS zusaetzlich `member-update` Nachrichten senden:
 
 Verbleibende Members MUESSEN ausserdem eine `key-rotation` Nachricht mit dem neuen Content Key und der neuen Capability erhalten. Der entfernte Member DARF diese `key-rotation` Nachricht nicht erhalten.
 
+### Operationelle Reihenfolge (MUSS)
+
+Damit offline Devices deterministisch aufholen koennen, MUSS eine Member-Entfernung als geordneter Sync-Flow behandelt werden:
+
+1. Der Admin erzeugt die Remove-CRDT-Operation und den neuen Key-Material-Satz lokal und persistiert beides gemaess [Sync 002 Lokaler Schreibvorgang](002-sync-protokoll.md#lokaler-schreibvorgang).
+2. Der Admin registriert die neue Capability-Key-Generation beim Broker (`space-rotate`) oder legt die Operation in eine retrybare Outbox, falls der Broker offline ist.
+3. Der Admin sendet `key-rotation` Inbox-Nachrichten an alle verbleibenden Members und `member-update` Nachrichten an verbleibende sowie entfernte Members. Diese Nachrichten MUESSEN pro Device zugestellt und ACKt werden (siehe [Sync 003 Store-and-Forward pro Device](003-transport-und-broker.md#store-and-forward-pro-device)).
+4. Verbleibende Members speichern die neue Generation durabel, bevor sie `key-rotation` ACKen. Danach MUESSEN sie einen Space-`sync-request` ausloesen und blockierte Log-Eintraege dieser Generation erneut verarbeiten.
+5. Entfernte Members duerfen `member-update(action="removed")` erst als dauerhaften lokalen Austritt behandeln, wenn der naechste Space-Sync die kanonische Mitgliederliste oder eine gueltige Rotation bestaetigt. Bis dahin SOLLTE die UI den Space als "Entfernung ausstehend" oder vergleichbar markieren.
+
+Zeitbasierte Snapshot- oder Vault-Retries duerfen diesen Ablauf beschleunigen, sind aber nicht normativ. Normative Konvergenz entsteht durch Inbox-Zustellung, Key-/Generation-Gap-Regeln und Log-Catch-Up gemaess [Sync 002 Key-Rotation und Generation-Gaps](002-sync-protokoll.md#key-rotation-und-generation-gaps).
+
 ### Key-Rotation Nachricht
 
 Inbox-Nachrichtentyp `key-rotation`, verschlüsselt mit ECIES:
@@ -225,6 +237,8 @@ Clients MUESSEN Key-Rotations anhand ihrer lokal bekannten Space-Key-Generation 
 - Wenn `generation` der lokal bekannten Generation plus eins entspricht, DARF die Rotation angewendet werden.
 - Wenn `generation` kleiner oder gleich der lokal bekannten Generation ist, MUSS die Rotation als doppelt oder veraltet ignoriert werden.
 - Wenn `generation` groesser als die lokal bekannte Generation plus eins ist, MUSS der Client die Rotation als zukuenftige Rotation behandeln. Er DARF sie puffern, MUSS fehlende Rotationen oder einen aktuellen Snapshot/Full-State nachladen und DARF die zukuenftige Rotation nicht anwenden, bevor die Luecke geschlossen ist.
+
+Die detaillierte Verarbeitung von `blocked-by-key` Log-Eintraegen, durabel gepufferten `future-rotation` Nachrichten und ACK-Zeitpunkten ist in [Sync 002 Normative Sync-Flows](002-sync-protokoll.md#normative-sync-flows) definiert.
 
 ## Concurrent-Verhalten
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -194,7 +194,7 @@ Damit offline Devices deterministisch aufholen koennen, MUSS eine Member-Entfern
 2. Der Admin registriert die neue Capability-Key-Generation beim Broker (`space-rotate`) oder legt die Operation in eine retrybare Outbox, falls der Broker offline ist.
 3. Der Admin sendet `key-rotation` Inbox-Nachrichten an alle verbleibenden Members und `member-update` Nachrichten an verbleibende sowie entfernte Members. Diese Nachrichten MUESSEN pro Device zugestellt und ACKt werden (siehe [Sync 003 Store-and-Forward pro Device](003-transport-und-broker.md#store-and-forward-pro-device)).
 4. Verbleibende Members speichern die neue Generation durabel, bevor sie `key-rotation` ACKen. Danach MUESSEN sie einen Space-`sync-request` ausloesen und blockierte Log-Eintraege dieser Generation erneut verarbeiten.
-5. Entfernte Members duerfen `member-update(action="removed")` erst als dauerhaften lokalen Austritt behandeln, wenn der naechste Space-Sync die kanonische Mitgliederliste oder eine gueltige Rotation bestaetigt. Bis dahin SOLLTE die UI den Space als "Entfernung ausstehend" oder vergleichbar markieren.
+5. Entfernte Members duerfen `member-update(action="removed")` erst als dauerhaften lokalen Austritt behandeln, wenn der naechste Space-Sync die kanonische Mitgliederliste ohne diese DID bestaetigt oder die Broker-Rotation fuer `effectiveKeyGeneration` die bisherige Capability mit `CAPABILITY_GENERATION_STALE` ablehnt. Bis dahin SOLLTE die UI den Space als "Entfernung ausstehend" oder vergleichbar markieren. Es gibt keinen normativen Timeout, weil Offline-Zeit keine neue Protokoll-Autoritaet erzeugt; bei App-Start oder Reconnect MUSS der Client den Bestaetigungs-Sync erneut versuchen. Implementierungen DUERFEN den Space lokal ausblenden oder Schreibaktionen sperren, DUERFEN lokalen State aber nicht ohne diese Bestaetigung als kanonisch geloescht behandeln.
 
 Zeitbasierte Snapshot- oder Vault-Retries duerfen diesen Ablauf beschleunigen, sind aber nicht normativ. Normative Konvergenz entsteht durch Inbox-Zustellung, Key-/Generation-Gap-Regeln und Log-Catch-Up gemaess [Sync 002 Key-Rotation und Generation-Gaps](002-sync-protokoll.md#key-rotation-und-generation-gaps).
 
@@ -236,7 +236,7 @@ Clients MUESSEN Key-Rotations anhand ihrer lokal bekannten Space-Key-Generation 
 
 - Wenn `generation` der lokal bekannten Generation plus eins entspricht, DARF die Rotation angewendet werden.
 - Wenn `generation` kleiner oder gleich der lokal bekannten Generation ist, MUSS die Rotation als doppelt oder veraltet ignoriert werden.
-- Wenn `generation` groesser als die lokal bekannte Generation plus eins ist, MUSS der Client die Rotation als zukuenftige Rotation behandeln. Er DARF sie puffern, MUSS fehlende Rotationen oder einen aktuellen Snapshot/Full-State nachladen und DARF die zukuenftige Rotation nicht anwenden, bevor die Luecke geschlossen ist.
+- Wenn `generation` groesser als die lokal bekannte Generation plus eins ist, MUSS der Client die Rotation als zukuenftige Rotation behandeln. Er DARF sie puffern, MUSS die in [Sync 002](002-sync-protokoll.md#key-rotation-und-generation-gaps) definierten Catch-Up-Quellen fuer fehlende Rotationen oder Keys nutzen und DARF die zukuenftige Rotation nicht anwenden, bevor die Luecke geschlossen ist.
 
 Die detaillierte Verarbeitung von `blocked-by-key` Log-Eintraegen, durabel gepufferten `future-rotation` Nachrichten und ACK-Zeitpunkten ist in [Sync 002 Normative Sync-Flows](002-sync-protokoll.md#normative-sync-flows) definiert.
 

--- a/03-wot-sync/006-personal-doc.md
+++ b/03-wot-sync/006-personal-doc.md
@@ -264,7 +264,9 @@ Das Personal Doc nutzt dieselbe Log-, Signatur-, Nonce- und DIDComm-Infrastruktu
 
 ### Self-Addressed Messages
 
-Personal-Doc-Nachrichten werden an die eigene DID adressiert. Der Broker routet sie an die anderen verbundenen Geräte derselben DID.
+Personal-Doc-Nachrichten werden an die eigene DID adressiert. Der Broker routet sie an die anderen verbundenen Geräte derselben DID. Die sendende `(did, deviceId)`-Verbindung darf ihre eigene Nachricht nicht als zugestellt ACKen; ACKs sind pro Device scoped (siehe [Sync 003 Store-and-Forward pro Device](003-transport-und-broker.md#store-and-forward-pro-device)).
+
+Beim Start oder Reconnect MUSS ein Client das Personal Doc vor Space-Dokumenten synchronisieren, weil Space-Mitgliedschaften und `groupKeys` im Personal Doc liegen. Space-Log-Eintraege mit unbekannter `keyGeneration` MUESSEN blockiert bleiben, bis Personal-Doc-Catch-Up oder eine `key-rotation` Inbox-Nachricht den passenden Key liefert (siehe [Sync 002 App-Start und Reconnect](002-sync-protokoll.md#app-start-und-reconnect)).
 
 ### Replikation auf mehreren Brokern
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -80,7 +80,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - `seq` pro `(deviceId, docId)` strikt monoton fuehren.
 - Restore/Clone-Erkennung bei `broker_seq > local_seq` umsetzen.
 - Kollisionen fuer `(docId, deviceId, seq)` erkennen und sicher behandeln.
-- App-Start- und Reconnect-Flows gemaess Sync 002 ausfuehren: lokalen Zustand laden, Broker authentisieren, Personal Doc zuerst syncen, danach Space-Dokumente ueber Heads/`sync-request` catch-upen.
+- App-Start- und Reconnect-Flows gemaess Sync 002 ausfuehren: lokalen Zustand laden, Broker authentisieren, Personal Doc zuerst syncen, danach fuer Space-Dokumente ueber Heads/`sync-request` einen Catch-Up durchfuehren.
 - Lokale Schreibvorgaenge zuerst persistent als Log-Eintrag speichern und erst danach an Broker/Peers publizieren.
 - Log-Eintraege mit fehlender `keyGeneration` als `blocked-by-key` behandeln und nach Key-Catch-Up erneut verarbeiten.
 - Snapshots und Full-State-Nachrichten nur als Optimierung mergen und niemals als Ersatz fuer Log-Catch-Up oder als Rollback bekannter gueltiger Eintraege verwenden.
@@ -93,7 +93,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Broker-Challenge-Response mit DID-Signaturen umsetzen.
 - Capabilities als JWS verifizieren.
 - Inbox-Nachrichten pro Device zustellen und ACKs verarbeiten.
-- Self-addressed Inbox-Nachrichten an andere Devices derselben DID zustellen, ohne das sendende Device als erfolgreich zugestellten Empfaenger zu behandeln.
+- Selbstadressierte Inbox-Nachrichten an andere Devices derselben DID zustellen, ohne das sendende Device als erfolgreich zugestellten Empfaenger zu behandeln.
 - Inbox-ACKs nur pro authentifiziertem Device anwenden und erst nach Entschluesselung, Verifikation, Replay-Pruefung und dauerhafter Anwendung oder durablem Pending-Speicher senden.
 
 ### Personal Doc und Gruppen
@@ -104,7 +104,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Invitee Encryption Keys ueber QR-Cache oder DID-Dokument `keyAgreement` aufloesen und fehlende Keys als Invite-Fehler behandeln.
 - `space-invite`, `member-update` und `key-rotation` Inbox-Nachrichten erzeugen, parsen und gegen die Space-Membership-Regeln pruefen.
 - Key-Rotation bei Member-Entfernung verarbeiten.
-- Key-Rotation-Generationen exakt nach Sync 005 anwenden: `local+1` anwenden, `<=local` ignorieren, `>local+1` durabel puffern und fehlende Rotationen/Keys/Full-State nachladen.
+- Key-Rotation-Generationen exakt nach Sync 005 anwenden: `local+1` anwenden, `<=local` ignorieren, `>local+1` durabel puffern und fehlende Rotationen/Keys ueber Device-Inbox, Personal-Doc-Catch-Up, Space-`sync-request` und optionale Snapshot-/Full-State-Quellen nachladen.
 - Nach `space-invite` und `key-rotation` einen Space-Catch-Up per `sync-request` ausloesen.
 
 ## `wot-device-delegation@0.1` (geplant)

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -80,6 +80,10 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - `seq` pro `(deviceId, docId)` strikt monoton fuehren.
 - Restore/Clone-Erkennung bei `broker_seq > local_seq` umsetzen.
 - Kollisionen fuer `(docId, deviceId, seq)` erkennen und sicher behandeln.
+- App-Start- und Reconnect-Flows gemaess Sync 002 ausfuehren: lokalen Zustand laden, Broker authentisieren, Personal Doc zuerst syncen, danach Space-Dokumente ueber Heads/`sync-request` catch-upen.
+- Lokale Schreibvorgaenge zuerst persistent als Log-Eintrag speichern und erst danach an Broker/Peers publizieren.
+- Log-Eintraege mit fehlender `keyGeneration` als `blocked-by-key` behandeln und nach Key-Catch-Up erneut verarbeiten.
+- Snapshots und Full-State-Nachrichten nur als Optimierung mergen und niemals als Ersatz fuer Log-Catch-Up oder als Rollback bekannter gueltiger Eintraege verwenden.
 
 ### Transport und Broker
 
@@ -89,6 +93,8 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Broker-Challenge-Response mit DID-Signaturen umsetzen.
 - Capabilities als JWS verifizieren.
 - Inbox-Nachrichten pro Device zustellen und ACKs verarbeiten.
+- Self-addressed Inbox-Nachrichten an andere Devices derselben DID zustellen, ohne das sendende Device als erfolgreich zugestellten Empfaenger zu behandeln.
+- Inbox-ACKs nur pro authentifiziertem Device anwenden und erst nach Entschluesselung, Verifikation, Replay-Pruefung und dauerhafter Anwendung oder durablem Pending-Speicher senden.
 
 ### Personal Doc und Gruppen
 
@@ -98,6 +104,8 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Invitee Encryption Keys ueber QR-Cache oder DID-Dokument `keyAgreement` aufloesen und fehlende Keys als Invite-Fehler behandeln.
 - `space-invite`, `member-update` und `key-rotation` Inbox-Nachrichten erzeugen, parsen und gegen die Space-Membership-Regeln pruefen.
 - Key-Rotation bei Member-Entfernung verarbeiten.
+- Key-Rotation-Generationen exakt nach Sync 005 anwenden: `local+1` anwenden, `<=local` ignorieren, `>local+1` durabel puffern und fehlende Rotationen/Keys/Full-State nachladen.
+- Nach `space-invite` und `key-rotation` einen Space-Catch-Up per `sync-request` ausloesen.
 
 ## `wot-device-delegation@0.1` (geplant)
 


### PR DESCRIPTION
Definiert normative Start-, Reconnect-, Inbox-, ACK- und Key-Rotation-Flows, damit Implementierungen fehlende Operationen deterministisch nachladen statt auf zeitbasierte Workarounds zu vertrauen.