### PR TITLE
Spec-Leseschicht und TS-Mapping ergänzen

### DIFF
--- a/01-wot-identity/001-identitaet-und-schluesselableitung.md
+++ b/01-wot-identity/001-identitaet-und-schluesselableitung.md
@@ -106,7 +106,7 @@ Eine sauberere Architektur wären **Per-Device Keys** — jedes Gerät hat ein e
 
 **Warum wir das jetzt nicht einführen:** `did:key` kann per Design nur einen einzigen Schlüssel ausdrücken — die DID *ist* der Public Key. Mehrere Device Keys im DID-Dokument setzen eine andere DID-Methode voraus ([did:peer:4](https://identity.foundation/peer-did-method-spec/) oder [did:webvh](https://identity.foundation/didwebvh/)).
 
-Der geplante Upgrade-Pfad ist deshalb stufenweise: Phase 2 erlaubt Device Keys über einen vom Identity Key signierten Delegation Proof, der zusammen mit der Signatur transportiert wird. Phase 3 migriert diese Autorisierung in eine Sigchain oder eine DID-Methode mit verifiable History wie `did:webvh`. Siehe [Device Keys](../research/device-keys.md), [Identitäts-Alternativen](../research/identitaet-alternativen.md) und [Identity Migration](../research/identity-migration.md) für den geplanten Pfad.
+Der geplante Upgrade-Pfad ist deshalb stufenweise: Phase 2 erlaubt Device Keys über einen vom Identity Key signierten Delegation Proof, der zusammen mit der Signatur transportiert wird. Dieses Modell ist als eigenes geplantes Erweiterungsprofil in [Identity 004](004-device-key-delegation.md) beschrieben und nicht Teil von `wot-identity@0.1`. Phase 3 migriert diese Autorisierung in eine Sigchain oder eine DID-Methode mit verifiable History wie `did:webvh`. Siehe außerdem [Device Keys](../research/device-keys.md), [Identitäts-Alternativen](../research/identitaet-alternativen.md) und [Identity Migration](../research/identity-migration.md) für den geplanten Pfad.
 
 ### Seed-Schutz auf dem Gerät
 

--- a/01-wot-identity/002-signaturen-und-verifikation.md
+++ b/01-wot-identity/002-signaturen-und-verifikation.md
@@ -22,7 +22,7 @@ Dieses Dokument spezifiziert wie Daten im Web of Trust signiert und verifiziert 
 
 ## Anforderungen
 
-- Alle signierten Daten MÜSSEN allein mit der DID des Signierers verifizierbar sein (kein externer Lookup nötig)
+- DID-gebundene Signaturen MUESSEN ueber `kid`, `resolve(did)` und das DID-Dokument verifizierbar sein; nicht-DID-gebundene Signaturen MUESSEN ihren kontextspezifischen Key-Resolver normativ angeben.
 - Das Signaturformat MUSS deterministische Verifikation unterstützen (gleiche Eingabe → gleiches Ergebnis)
 - Die Kanonisierungsmethode MUSS eindeutig sein
 
@@ -43,7 +43,7 @@ BASE64URL(header) . BASE64URL(payload) . BASE64URL(signature)
 **Header:**
 
 ```json
-{ "alg": "EdDSA", "typ": "<kontextspezifisch>", "kid": "<DID-URL>" }
+{ "alg": "EdDSA", "typ": "<kontextspezifisch>", "kid": "<Key-Identifier>" }
 ```
 
 `kid` (Key Identifier) ist **PFLICHT** in jedem WoT-JWS. Es identifiziert welcher konkrete Key die Signatur erzeugt hat. Für DID-gebundene Signaturen ist `kid` eine DID-URL mit Fragment (z.B. `did:key:z6Mk...#sig-0`). Der Verifier nutzt `kid` um über `resolve()` ([Identity 003](003-did-resolution.md)) den richtigen Public Key zu finden. In Phase 1 ist das Fragment immer `#sig-0` (einziger Key). In Phase 2 (Per-Device-Keys) zeigt es auf den spezifischen Device-Key.
@@ -137,17 +137,17 @@ Für die Verifikation werden benötigt:
 
 **Wichtig:** Der Verifier darf den Payload NICHT neu kanonisieren oder neu serialisieren. Kanonisierung (JCS) findet ausschließlich auf Sender-Seite statt, **bevor** Base64URL-Kodierung. Auf Empfängerseite werden die empfangenen Bytes 1:1 verifiziert. Re-Kanonisierung bei der Verifikation würde abweichende Bytes erzeugen und gültige Signaturen fälschlich ablehnen.
 
-Kein externer Key-Server oder Zertifikatskette nötig — die DID selbst enthält den Public Key.
+Kein vertrauenswuerdiger externer Key-Server oder eine Zertifikatskette ist noetig. DID-gebundene Signaturen werden ueber DID-Dokumente verifiziert; kontextspezifische Signaturen wie Space-Capabilities werden ueber den im jeweiligen Protokolldokument definierten Kontext-Resolver verifiziert.
 
 ### kid-Konsistenz (MUSS)
 
 Der Verifier MUSS prüfen, dass `kid` mit dem Signierer- oder Kontext-Identifier im Payload konsistent ist. Konkret:
 
-- Bei Attestations: `kid` MUSS zur DID in `iss` / `issuer` passen
-- Bei Log-Einträgen: `kid` MUSS zur DID in `authorKid` passen
+- Bei direkten Attestation-Signaturen in `wot-trust@0.1`: Die DID im `kid` MUSS zur DID in `iss` / `issuer` passen. Delegierte Device-Key-Signaturen folgen den Regeln aus [Identity 004](004-device-key-delegation.md).
+- Bei Log-Einträgen: `kid` MUSS dem `authorKid` entsprechen.
 - Bei Space-Capabilities: `kid` MUSS `spaceId` und `generation` referenzieren (Format: `wot:space:<spaceId>#cap-<generation>`)
 
-"Passen" bedeutet bei DID-gebundenen Signaturen: die DID im `kid` (ohne Fragment) MUSS identisch sein mit der DID im Payload. Bei Space-Capabilities MUSS der Space-Kontext im `kid` mit dem Payload übereinstimmen. Andernfalls MUSS der Verifier den JWS ablehnen — ein Mismatch deutet auf Manipulation hin.
+"Passen" bedeutet bei direkten DID-gebundenen Signaturen: die DID im `kid` (ohne Fragment) MUSS identisch sein mit der DID im Payload. Bei Space-Capabilities MUSS der Space-Kontext im `kid` mit dem Payload uebereinstimmen. Bei delegierten Signaturen MUSS der Delegation Proof die Beziehung zwischen Device Key und Identity DID herstellen. Andernfalls MUSS der Verifier den JWS ablehnen — ein Mismatch deutet auf Manipulation hin.
 
 ### Algorithmus-Validierung (MUSS)
 

--- a/01-wot-identity/003-did-resolution.md
+++ b/01-wot-identity/003-did-resolution.md
@@ -151,7 +151,7 @@ Ein Verifier MUSS prüfen dass der verwendete Key für den jeweiligen Zweck auto
 - **Broker-Login und Sync** DÜRFEN mit einem Key aus `authentication` signiert werden — das sind Session-bezogene Aktionen
 - **Device-Enrollment und Admin-Delegation** SOLLEN mit einem Key aus `capabilityDelegation` signiert werden (Phase 2)
 
-In Phase 1 verweisen `authentication`, `assertionMethod` und `capabilityDelegation` alle auf denselben Key (`#sig-0`). Die Trennung hat aktuell keine praktische Auswirkung, bereitet aber den Wechsel zu Per-Device-Keys vor: Device Keys stehen dann typischerweise in `authentication` und koennen ueber Delegation Proofs zusaetzliche, capability-gebundene Signaturrechte erhalten. Das Delegation-Modell ist noch nicht Teil von `wot-identity@0.1`; siehe [Device Keys](../research/device-keys.md).
+In Phase 1 verweisen `authentication`, `assertionMethod` und `capabilityDelegation` alle auf denselben Key (`#sig-0`). Die Trennung hat aktuell keine praktische Auswirkung, bereitet aber den Wechsel zu Per-Device-Keys vor: Device Keys stehen dann typischerweise in `authentication` und koennen ueber Delegation Proofs zusaetzliche, capability-gebundene Signaturrechte erhalten. Das Delegation-Modell ist noch nicht Teil von `wot-identity@0.1`; siehe [Identity 004](004-device-key-delegation.md).
 
 ## DID-Dokument-Quellen
 
@@ -260,7 +260,7 @@ resolve("did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK")
    }
 ```
 
-**Das keyAgreement-Problem bei did:key:**
+#### Das keyAgreement-Problem bei did:key
 
 Der X25519 Encryption Key wird über einen separaten HKDF-Pfad abgeleitet (siehe [Identity 001](001-identitaet-und-schluesselableitung.md)) und ist **nicht aus der `did:key` ableitbar**. Deshalb ist `keyAgreement` im generierten Dokument zunächst leer.
 

--- a/01-wot-identity/004-device-key-delegation.md
+++ b/01-wot-identity/004-device-key-delegation.md
@@ -20,6 +20,12 @@ Das Modell besteht aus:
 
 Device DIDs sind keine sozialen Identitaeten. Sie sind technische Signing Keys, die durch die Identity DID fuer konkrete Capabilities delegiert werden.
 
+## Architektur-Schnitt
+
+Device-Key-Delegation liegt in der Identity-Dokumentfamilie, weil sie das Key-/Authority-Modell einer Identity DID erweitert: Welche technischen Keys duerfen fuer diese Identity handeln?
+
+Sie ist trotzdem nicht Teil des Identity-Core-Profils `wot-identity@0.1`. Implementierungen von `wot-identity@0.1` muessen nur Identity Keys, DID-Resolution und direkte JWS-Signaturen beherrschen. Device-Key-Delegation ist ein eigenes geplantes Erweiterungsprofil, das von Trust und Sync konsumiert wird, wenn delegierte Attestations, delegierte Log-Signaturen oder Device-basierte Broker-Authentisierung verwendet werden.
+
 ## Identitaetsmodell
 
 In Phase 2 nutzt jedes Geraet eine eigene `did:key`-DID:
@@ -114,7 +120,7 @@ DeviceKeyBinding wird als JWS Compact Serialization signiert.
 
 - `alg` MUSS `"EdDSA"` sein.
 - `kid` MUSS auf den Identity Key zeigen, der `iss` kontrolliert.
-- `typ` SOLLTE `"wot-device-key-binding+jwt"` sein.
+- `typ` MUSS `"wot-device-key-binding+jwt"` sein.
 
 ## Delegated-Attestation-Bundle
 

--- a/01-wot-identity/README.md
+++ b/01-wot-identity/README.md
@@ -1,0 +1,87 @@
+# WoT Identity
+
+Diese README ist eine Leseschicht fuer die Identity-Dokumentfamilie. Normative Anforderungen stehen in den nummerierten Dokumenten und in `CONFORMANCE.md`.
+
+WoT Identity klaert Keys, DID-Dokumente, JWS-Verifikation und Zweckbindung. Trust nutzt diese Basis fuer Attestations; Sync nutzt sie fuer Broker-Auth, Log-Signaturen, Inbox-Adressierung und Verschluesselungs-Key-Discovery.
+
+## Dokumente
+
+| # | Dokument | Rolle |
+|---|---|---|
+| 001 | [Identitaet und Schluesselableitung](001-identitaet-und-schluesselableitung.md) | BIP39-Seed, HKDF-Pfade, Identity Key, Encryption Key, Shared-Seed-Modell. |
+| 002 | [Signaturen und Verifikation](002-signaturen-und-verifikation.md) | JWS Compact Serialization, JCS, `kid`, Algorithmus-Whitelist und Signaturpruefung. |
+| 003 | [DID-Dokument und Resolution](003-did-resolution.md) | DID-Dokument-Struktur, `resolve(did)`, `did:key`, `did:webvh`-Pfad und Zweckbindung. |
+| 004 | [Device-Key-Delegation](004-device-key-delegation.md) | Geplantes Erweiterungsdokument fuer DeviceKeyBinding und delegierte Device-Signaturen. |
+
+## Identity-Schnitt
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"background": "transparent", "primaryColor": "#f8fafc", "primaryTextColor": "#111827", "primaryBorderColor": "#64748b", "lineColor": "#94a3b8", "tertiaryColor": "#f8fafc", "fontFamily": "system-ui, sans-serif"}}}%%
+flowchart TD
+  Seed[BIP39 Seed]
+  IKey[Identity Key]
+  EKey[Encryption Key]
+  Did[DID Document]
+  Jws[JWS Verification]
+  Trust[Trust]
+  Sync[Sync]
+
+  Seed --> IKey
+  Seed --> EKey
+  IKey --> Did
+  Did --> Jws
+  Jws --> Trust
+  Jws --> Sync
+  EKey --> Sync
+```
+
+| Baustein | Rolle | Normative Quelle |
+|---|---|---|
+| BIP39 Seed | Gemeinsamer Root fuer deterministic recovery. | [Identity 001: Seed](001-identitaet-und-schluesselableitung.md#seed) |
+| Identity Key | Ed25519-Key fuer Identity-gebundene Signaturen. | [Identity 001: Schluesselpaar](001-identitaet-und-schluesselableitung.md#schlüsselpaar), [Identity 002: Signaturalgorithmus](002-signaturen-und-verifikation.md#signaturalgorithmus) |
+| Encryption Key | X25519-Key fuer ECIES und Inbox-Kommunikation. | [Identity 001: Weitere Schluessel](001-identitaet-und-schluesselableitung.md#weitere-schlüssel), [Sync 001: Encryption Key Discovery](../03-wot-sync/001-verschluesselung.md#encryption-key-discovery) |
+| DID-Dokument | Resolver-Ergebnis mit Verification Methods, Key-Zwecken und optionalen Services. | [Identity 003: DID-Dokument-Struktur](003-did-resolution.md#did-dokument-struktur), [Identity 003: resolve()](003-did-resolution.md#resolve--das-interface) |
+| JWS Verification | Signaturmechanik: `kid`, Signing Input, Algorithmus-Whitelist und Public-Key-Aufloesung. | [Identity 002: Signaturformat](002-signaturen-und-verifikation.md#signaturformat-jws-compact-serialization-rfc-7515), [Identity 002: Verifikation](002-signaturen-und-verifikation.md#verifikation) |
+
+## Identity Core und Conformance-Profil
+
+Der Identity Core ist die normative Basis fuer DID-gebundene Keys, JWS und Resolution. [`wot-identity@0.1`](../CONFORMANCE.md#wot-identity01) ist der daraus abgeleitete Conformance-Claim fuer Implementierungen.
+
+1. [BIP39-Seed-Ableitung mit leerer Passphrase](001-identitaet-und-schluesselableitung.md#seed).
+2. [HKDF-Info-Strings fuer Identity- und Encryption-Key-Material](001-identitaet-und-schluesselableitung.md#weitere-schlüssel).
+3. [Ed25519-JWS mit `alg=EdDSA`, JCS und strikter Algorithmus-Whitelist](002-signaturen-und-verifikation.md#algorithmus-validierung-muss).
+4. [`did:key` fuer Ed25519-Identity-Keys](003-did-resolution.md#didkey-phase-1--normativ).
+5. [`resolve(did)` fuer DID-Dokumente](003-did-resolution.md#resolve--das-interface) und [Zweckbindung](003-did-resolution.md#zweck-bindung-muss).
+
+Nicht im Identity Core enthalten sind soziale Trust-Semantik, Sync-Transport, Broker-Protokolle, Space-Capabilities und Device-Key-Delegation.
+
+## Resolver-Zustaende
+
+[`did:key`](003-did-resolution.md#didkey-phase-1--normativ) macht WoT in Phase 1 einfach, aber nicht vollstaendig kommunikationsfaehig. Die DID enthaelt nur den Ed25519-Public-Key. Der X25519-Key entsteht aus einem [separaten HKDF-Pfad](001-identitaet-und-schluesselableitung.md#weitere-schlüssel) und ist nicht aus der DID ableitbar.
+
+| Zustand | Was ist verfuegbar? | Reicht fuer |
+|---|---|---|
+| Signaturfaehig | DID, Ed25519 Verification Method, `authentication`, `assertionMethod`, leeres `keyAgreement`. | Signaturverifikation, Challenge-Response, Broker-Auth. |
+| Kommunikationsfaehig | Zusaetzlich `keyAgreement` und optional `service`. | ECIES, Inbox-Zustellung, Profil-/Broker-Discovery. |
+
+Diese Trennung ist zentral: Ein gueltiges `did:key` reicht zum Verifizieren einer Attestation, aber nicht zum Verschluesseln einer Inbox-Nachricht. Dafuer braucht der Resolver den oeffentlichen X25519 Encryption Key des Empfaengers als `keyAgreement` und fuer Inbox-Zustellung ggf. einen `service`-Endpoint. Diese Werte kommen aus [QR-Code, Profil-Service oder lokalem Cache](003-did-resolution.md#did-dokument-quellen).
+
+## Signaturverifikation
+
+Identity 002 definiert den gemeinsamen Verifikationskern: JWS-Form, Algorithmus-Whitelist, `kid`-Aufloesung und Signaturpruefung. Identity 003 liefert die Zweckbindung. Die Semantik des signierten Objekts bleibt bei der hoeheren Schicht: Trust prueft Attestations, Sync prueft Log-Eintraege und Capabilities.
+
+Einstiege: [Identity 002: Verifikation](002-signaturen-und-verifikation.md#verifikation), [Identity 003: Zweck-Bindung](003-did-resolution.md#zweck-bindung-muss), [Trust 001: Verifikation](../02-wot-trust/001-attestations.md#verifikation), [Sync 002: Log-Eintrag](../03-wot-sync/002-sync-protokoll.md#log-eintrag).
+
+## Device-Key-Delegation
+
+[Device-Key-Delegation](004-device-key-delegation.md#architektur-schnitt) ist ein geplantes Erweiterungsdokument in der Identity-Dokumentfamilie, aber nicht Teil von [`wot-identity@0.1`](../CONFORMANCE.md#wot-identity01). Es klaert, welcher technische Device Key fuer eine Identity DID handeln darf. Trust und Sync konsumieren diese Autorisierung, definieren sie aber nicht selbst.
+
+## Offene Architektur-Kanten
+
+| Punkt | Einordnung |
+|---|---|
+| [`did:key` plus separater X25519-Key](003-did-resolution.md#das-keyagreement-problem-bei-didkey) | Phase-1-Workaround; Resolver muss Zusatzquellen fuer `keyAgreement` nutzen. |
+| [Device-UUIDs](../03-wot-sync/002-sync-protokoll.md#device-identifikation) | Sync-Log-Namespace, kein kryptographischer Key. |
+| [Device-Key-Delegation](004-device-key-delegation.md#architektur-schnitt) | Geplantes Erweiterungsdokument, nicht Teil von `wot-identity@0.1`. |
+| [did:webvh](003-did-resolution.md#didwebvh-phase-2--informativ-nicht-normativ) | Geplanter Resolver mit verifiable History, nicht Pflicht fuer Phase 1. |
+| [Space-Capabilities](../03-wot-sync/003-transport-und-broker.md#autorisierung-capabilities) | Nutzen JWS, aber ihr `kid` ist kein DID-URL; Verifikation laeuft ueber Space-Kontext. |

--- a/02-wot-trust/001-attestations.md
+++ b/02-wot-trust/001-attestations.md
@@ -60,7 +60,7 @@ Eine WoT Attestation ist ein W3C Verifiable Credential 2.0, gesichert als JWS (V
 }
 ```
 
-Die letzten vier Felder sind **JWT Registered Claims** (RFC 7519) — redundant zu den VC-Feldern darüber, aber nötig für Kompatibilität mit Standard-JWT-Bibliotheken und externen VC-Verifiern:
+Die JWT-Felder sind **JWT Registered Claims** (RFC 7519) — redundant zu den VC-Feldern darüber, aber nötig für Kompatibilität mit Standard-JWT-Bibliotheken und externen VC-Verifiern:
 
 | JWT Claim | VC-Feld | Wert |
 |---|---|---|
@@ -178,7 +178,7 @@ Um eine Attestation zu verifizieren:
 
 Kein externer Service nötig für die Signatur-Verifikation. Alles lokal verifizierbar (DID-Dokument aus Cache). Nur die StatusList-Prüfung (Schritt 9) kann einen optionalen Online-Abruf erfordern.
 
-**Geplante Phase-2-Erweiterung:** Attestations koennen spaeter auch mit einem delegierten Device Key signiert werden. Dann bleibt `iss` die Identity DID, der JWS-Header `kid` zeigt auf den Device Key, und der Verifier prueft zusaetzlich einen vom Identity Key signierten Delegation Proof. Der Proof begrenzt die Signaturberechtigung des Device Keys, nicht die Gueltigkeit der Attestation selbst. Er bindet Device Key, Identity DID, Ausstellungszeitpunkt und die Capability `sign-attestation` bzw. `sign-verification`. Das geplante Bundle ist ein JSON-Container mit Attestation-JWS und DeviceKeyBinding-JWS; es ist nicht Teil von `wot-trust@0.1`. Siehe [Device Keys](../research/device-keys.md).
+**Geplante Phase-2-Erweiterung:** Attestations koennen spaeter auch mit einem delegierten Device Key signiert werden. Dann bleibt `iss` die Identity DID, der JWS-Header `kid` zeigt auf den Device Key, und der Verifier prueft zusaetzlich einen vom Identity Key signierten Delegation Proof. Der Proof begrenzt die Signaturberechtigung des Device Keys, nicht die Gueltigkeit der Attestation selbst. Er bindet Device Key, Identity DID, Ausstellungszeitpunkt und die Capability `sign-attestation` bzw. `sign-verification`. Das geplante Bundle ist ein JSON-Container mit Attestation-JWS und DeviceKeyBinding-JWS; es ist nicht Teil von `wot-trust@0.1`. Siehe [Identity 004](../01-wot-identity/004-device-key-delegation.md).
 
 ## Subjects
 

--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -32,7 +32,7 @@ Im Normalfall reicht **ein einziger QR-Scan** für eine gegenseitige Verifikatio
 
 ## QR-Code-Format
 
-Jeder User zeigt einen QR-Code, der als Challenge fungiert. Er enthält alle Informationen die der Gegenüber braucht — inklusive Encryption Key und Broker-URL, damit der Flow **komplett offline** funktioniert. DIDComm definiert ein ähnliches Konzept (Out-of-Band Invitation), das aber DID-Resolution voraussetzt und keine Challenge-Nonce enthält. Unser Format ist reicher und offline-tauglicher.
+Jeder User zeigt einen QR-Code, der als Challenge fungiert. Er enthält die Informationen, die der Gegenüber für sofortige lokale Verifikation und spätere verschlüsselte Zustellung braucht — insbesondere den Encryption Key und optional eine Broker-URL. DIDComm definiert ein ähnliches Konzept (Out-of-Band Invitation), das aber DID-Resolution voraussetzt und keine Challenge-Nonce enthält. Unser Format ist reicher und offline-tauglicher.
 
 ```json
 {

--- a/02-wot-trust/README.md
+++ b/02-wot-trust/README.md
@@ -1,0 +1,70 @@
+# WoT Trust
+
+Diese README ist eine Leseschicht fuer die Trust-Dokumentfamilie. Normative Anforderungen stehen in den nummerierten Dokumenten und in `CONFORMANCE.md`.
+
+WoT Trust klaert signierte Aussagen zwischen Identitaeten und reale Verifikation. Identity liefert Keys, DID-Resolution und JWS-Verifikation; Sync transportiert Attestations und Verification-Attestations, definiert aber nicht ihre Trust-Semantik.
+
+## Dokumente
+
+| # | Dokument | Rolle |
+|---|---|---|
+| 001 | [Attestations](001-attestations.md) | W3C VC 2.0 Payloads, VC-JOSE-COSE/JWS, Empfaengerprinzip, Verifikation. |
+| 002 | [Verifikation](002-verifikation.md) | QR-Challenges, In-Person-Verifikation, Nonce-History, Verification-Attestations. |
+
+## Trust-Schnitt
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"background": "transparent", "primaryColor": "#f8fafc", "primaryTextColor": "#111827", "primaryBorderColor": "#64748b", "lineColor": "#94a3b8", "tertiaryColor": "#f8fafc", "fontFamily": "system-ui, sans-serif"}}}%%
+flowchart TD
+  Identity[Identity]
+  Challenge[QR Challenge]
+  Verification[Verification]
+  Attestation[Attestation VC-JWS]
+  Holder[Holder Wallet]
+  Sync[Sync / Profile]
+
+  Identity --> Verification
+  Challenge --> Verification
+  Verification --> Attestation
+  Attestation --> Holder
+  Holder --> Sync
+```
+
+| Baustein | Rolle | Normative Quelle |
+|---|---|---|
+| Identity | Issuer und Subject sind DIDs; JWS-Keys werden ueber Identity aufgeloest. | [Identity 002](../01-wot-identity/002-signaturen-und-verifikation.md#verifikation), [Identity 003](../01-wot-identity/003-did-resolution.md#resolve--das-interface) |
+| QR Challenge | Temporärer Nachweis fuer In-Person- oder vertrauenswuerdigen Kanal. | [Trust 002: QR-Code-Format](002-verifikation.md#qr-code-format) |
+| Verification | Bindet eine Verification-Attestation an eine aktive Challenge-Nonce oder an eine Remote-Verifikation. | [Trust 002: Acceptance Gate](002-verifikation.md#acceptance-gate-fuer-online-verifikation-muss) |
+| Attestation VC-JWS | Signierte Aussage als W3C VC 2.0, transportiert als JWS. | [Trust 001: Format](001-attestations.md#format), [Trust 001: Verifikation](001-attestations.md#verifikation) |
+| Holder Wallet | Subject besitzt die Attestation und entscheidet ueber Veroeffentlichung. | [Trust 001: Empfaengerprinzip](001-attestations.md#empfängerprinzip) |
+
+## Trust Core und Conformance-Profil
+
+[`wot-trust@0.1`](../CONFORMANCE.md#wot-trust01) baut auf [`wot-identity@0.1`](../CONFORMANCE.md#wot-identity01) auf. Die Source of Truth sind die verlinkten Spec-Abschnitte:
+
+1. [Attestation-Payloads als W3C VC 2.0](001-attestations.md#format).
+2. [VC-JOSE-COSE/JWS mit `typ: "vc+jwt"`](001-attestations.md#transport-jws-compact-serialization-vc-jose-cose-profil).
+3. [Issuer-/Subject-Konsistenz und Attestation-Verifikation](001-attestations.md#verifikation).
+4. [QR-Challenge-Parsing](002-verifikation.md#qr-code-format).
+5. [Nonce-History und Acceptance Gate fuer Online-In-Person-Verifikation](002-verifikation.md#acceptance-gate-fuer-online-verifikation-muss).
+
+Nicht im Trust Core enthalten sind Sync-Zustellung, Broker-Routing, Device-Key-Authority, Trust-Score-Algorithmen und App-spezifische Darstellung.
+
+## Grenzen
+
+| Grenze | Einordnung |
+|---|---|
+| Identity vs. Trust | Identity sagt, ob eine Signatur und ihr Key gueltig sind. Trust sagt, ob die signierte Aussage als Attestation oder Verification akzeptiert wird. |
+| Trust vs. Sync | Trust definiert Attestation-Semantik. Sync transportiert, speichert und repliziert die JWS-Objekte. |
+| Attestation vs. Presentation | WoT Trust nutzt VC-JWS direkt. Verifiable Presentations sind spaetere externe Interop-Erweiterung. |
+| Verification vs. Trust-Score | Verification bestaetigt Begegnung oder Identitaetsbezug. Quantitative Bewertung ist Extension-Semantik, z.B. HMC. |
+| Device-Key-Delegation | Delegierte Signaturen werden in Identity 004 autorisiert; Trust konsumiert diese Autorisierung nur. |
+
+## Offene Architektur-Kanten
+
+| Punkt | Einordnung |
+|---|---|
+| Remote-Verifikation | Schwaecher als In-Person-Verifikation; Implementierungen duerfen sie anders darstellen oder gewichten. |
+| Verifiable Presentations | Nicht Teil von `wot-trust@0.1`, aber fuer externe VC-Interop vorbereitet. |
+| Credential Status | Optionales Feld; konkrete Widerrufssemantik liegt bei Extensions. |
+| Device-Key-Delegation | Geplantes Erweiterungsprofil; normale `wot-trust@0.1`-Attestations bleiben Identity-Key-signiert. |

--- a/03-wot-sync/README.md
+++ b/03-wot-sync/README.md
@@ -1,0 +1,88 @@
+# WoT Sync
+
+Diese README ist eine Leseschicht fuer die Sync-Dokumentfamilie. Normative Anforderungen stehen in den nummerierten Dokumenten und in `CONFORMANCE.md`.
+
+WoT Sync klaert verschluesselten Local-First-Sync, Broker, Inbox, Spaces und Personal Doc. Identity liefert Keys, DID-Resolution und Signaturverifikation. Trust-Artefakte koennen ueber Sync transportiert werden; Sync definiert aber nicht ihre Trust-Semantik.
+
+## Dokumente
+
+| # | Dokument | Rolle |
+|---|---|---|
+| 001 | [Verschluesselung](001-verschluesselung.md) | AES-256-GCM, ECIES, Encryption-Key-Discovery, Space Keys und Nonce-Konstruktion. |
+| 002 | [Sync-Protokoll](002-sync-protokoll.md) | Append-only Logs, `seq`, Log-Entry-JWS, normative Sync-Flows und Generation-Gaps. |
+| 003 | [Transport und Broker](003-transport-und-broker.md) | Broker, Authentisierung, Capabilities, per-Device-Inbox, DIDComm-kompatible Plaintext-Envelopes und P2P-Sync. |
+| 004 | [Discovery](004-discovery.md) | Broker-Discovery, Profil-Service, DID-Dokument-Quelle und oeffentliche Profilressourcen. |
+| 005 | [Gruppen und Mitgliedschaft](005-gruppen.md) | Spaces, Einladungen, Member-Updates, Admin Keys und Key-Rotation. |
+| 006 | [Personal Doc und Cross-Device Sync](006-personal-doc.md) | Persoenliches verschluesseltes Dokument, Device-Lifecycle, Self-Addressed Messages und Cross-Device-Recovery. |
+
+## Sync-Schnitt
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"background": "transparent", "primaryColor": "#f8fafc", "primaryTextColor": "#111827", "primaryBorderColor": "#64748b", "lineColor": "#94a3b8", "tertiaryColor": "#f8fafc", "fontFamily": "system-ui, sans-serif"}}}%%
+flowchart TD
+  Identity[Identity]
+  Encryption[Encryption]
+  Log[Append-only Log]
+  Personal[Personal Doc]
+  Space[Space]
+  Inbox[Inbox]
+  Envelope[WoT Envelope]
+  Broker[Broker / P2P]
+  Discovery[Discovery]
+
+  Identity --> Encryption
+  Encryption --> Log
+  Personal --> Log
+  Space --> Log
+  Log --> Envelope
+  Inbox --> Envelope
+  Envelope --> Broker
+  Discovery --> Broker
+```
+
+| Baustein | Rolle | Normative Quelle |
+|---|---|---|
+| Encryption | Schuetzt Inbox-, Space- und Personal-Doc-Payloads vor dem Transport. | [Sync 001: Verschluesselungs-Schluessel](001-verschluesselung.md#verschlüsselungs-schlüssel), [Sync 001: ECIES](001-verschluesselung.md#peer-to-peer-verschlüsselung-ecies) |
+| Append-only Log | Interop-Baseline fuer Dokument-Sync; CRDT-Payload bleibt opak. | [Sync 002: Log](002-sync-protokoll.md#log), [Sync 002: CRDT-Agnostik](002-sync-protokoll.md#crdt-agnostik) |
+| Normative Sync-Flows | Reihenfolge fuer Start/Reconnect, lokale Writes, Inbox-ACK, Invites und Generation-Gaps. | [Sync 002: Normative Sync-Flows](002-sync-protokoll.md#normative-sync-flows) |
+| Broker / P2P | Immer-online Peer oder direkter Peer; ergaenzt Auth, Store-and-Forward, Capabilities und Push. | [Sync 003: Broker](003-transport-und-broker.md#broker), [Sync 003: Direkter P2P-Sync](003-transport-und-broker.md#direkter-p2p-sync) |
+| WoT Envelope | Ephemeres DIDComm-kompatibles Plaintext-Framing fuer Sync-Nachrichten. | [Sync 003: WoT Message Envelope](003-transport-und-broker.md#wot-message-envelope-didcomm-kompatibel) |
+| Inbox | Per-Device Store-and-Forward fuer direkte verschluesselte Nachrichten und Control-Messages. | [Sync 003: Store-and-Forward pro Device](003-transport-und-broker.md#store-and-forward-pro-device), [Sync 002: Inbox-Verarbeitung](002-sync-protokoll.md#inbox-verarbeitung-und-ack) |
+| Capabilities | Broker-Autorisierung fuer Space- und Personal-Doc-Zugriff. | [Sync 003: Autorisierung](003-transport-und-broker.md#autorisierung-capabilities), [Sync 005: Capability-Pruefung](005-gruppen.md#capability-prüfung) |
+| Discovery | Findet Broker, Profil-Service, DID-Dokumente und Encryption Keys. | [Sync 004: Broker-Discovery](004-discovery.md#broker-discovery), [Sync 004: Profil-Service](004-discovery.md#profil-service) |
+| Spaces | Gruppen-Dokumente mit Content Keys, Capability Keys, Member-Updates und Rotation. | [Sync 005: Grundprinzip](005-gruppen.md#grundprinzip), [Sync 005: Key-Rotation](005-gruppen.md#key-rotation-member-entfernung) |
+| Personal Doc | Persoenliches Dokument fuer Profil, Kontakte, Attestations, Spaces, Group Keys und Devices. | [Sync 006: Struktur des Personal Doc](006-personal-doc.md#struktur-des-personal-doc), [Sync 006: Sync-Mechanismus](006-personal-doc.md#sync-mechanismus) |
+
+## Sync Core und Conformance-Profil
+
+[`wot-sync@0.1`](../CONFORMANCE.md#wot-sync01) baut auf [`wot-identity@0.1`](../CONFORMANCE.md#wot-identity01) auf. `wot-trust@0.1` ist fuer Sync nicht erforderlich. Die Source of Truth sind die verlinkten Spec-Abschnitte:
+
+1. [AES-256-GCM, ECIES und Encryption-Key-Discovery](001-verschluesselung.md).
+2. [Append-only Log, `seq`-Konsistenz und Log-Entry-JWS](002-sync-protokoll.md#log).
+3. [Normative Sync-Flows](002-sync-protokoll.md#normative-sync-flows).
+4. [Broker-Authentisierung, Capabilities und per-Device-Inbox](003-transport-und-broker.md).
+5. [DIDComm-kompatibles Plaintext-Envelope als ephemeres Transport-Framing](003-transport-und-broker.md#wot-message-envelope-didcomm-kompatibel).
+6. [Discovery](004-discovery.md), [Gruppen](005-gruppen.md) und [Personal Doc](006-personal-doc.md).
+
+Nicht im Sync Core enthalten sind Trust-Score-Algorithmen, App-spezifische CRDT-Semantik, UI-Zustaende, DIDComm-JWE/Authcrypt, Broker-zu-Broker-Replikation und zukuenftige Log-Kompression oder Set-Reconciliation.
+
+## Grenzen
+
+| Grenze | Einordnung |
+|---|---|
+| Sync vs. Identity | Identity sagt, wer signieren und entschluesseln kann. Sync nutzt diese Keys fuer Broker-Auth, Log-Entry-Verifikation und Inbox-Verschluesselung. |
+| Sync vs. Trust | Sync transportiert Attestations und Verifications, bewertet sie aber nicht. Trust prueft ihre Semantik. |
+| Log vs. Envelope | Log-Eintraege, Capabilities und Attestations sind persistente WoT-Objekte. Envelopes sind ephemeres Transport-Framing. |
+| Broker vs. Peer | Der Broker ist ein immer-online Peer mit Store-and-Forward, Auth und Capability-Pruefung; das Sync-Protokoll bleibt peer-agnostisch. |
+| Space vs. Personal Doc | Beide nutzen dieselbe Log-Infrastruktur. Spaces verteilen zufaellige Group Keys, das Personal Doc leitet seinen Key deterministisch aus dem Seed ab. |
+| CRDT vs. Sync | Sync transportiert verschluesselte Payloads und Heads; die konkrete CRDT-Semantik liegt bei der App oder Extension. |
+
+## Offene Architektur-Kanten
+
+| Punkt | Einordnung |
+|---|---|
+| Log-Kompression und Set-Reconciliation | Als Phase 2/3 beschrieben, aber nicht Teil von `wot-sync@0.1`. |
+| Snapshots und Full-State | Optionale Optimierungen; sie ersetzen keinen Log-Catch-Up und duerfen bekannte gueltige Log-Eintraege nicht zurueckrollen. |
+| Broker-zu-Broker-Replikation | Nicht normiert; Clients synchronisieren mehrere Broker lokal und vergleichen Heads. |
+| P2P ohne Broker | Unterstuetzt direkte Sync-Runden, aber keine garantierte Store-and-Forward-Inbox. |
+| Device-Key-Delegation | Geplantes Identity-Erweiterungsprofil; Sync nutzt delegierte Signaturen erst, wenn Identity sie autorisiert. |

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,86 @@
+# Architektur-Kompass
+
+> **Nicht normativ:** Dieses Dokument ist ein Arbeitskompass fuer Spec-Architektur und Implementierungs-Mapping. Normative Anforderungen stehen in den nummerierten Spec-Dokumenten, Schemas, Test-Vektoren und `CONFORMANCE.md`.
+
+## Ziel
+
+Diese Arbeit soll ein gemeinsames Architekturverstaendnis schaffen, bevor die TypeScript-Implementierung weiter umgebaut wird.
+
+Das Zielbild ist:
+
+```txt
+Spec mit klaren Dokumentgrenzen
++ Abschnitts-READMEs als Lesefuehrung
++ pruefbare Conformance-Artefakte
++ TypeScript-Mapping ohne implizite Architekturentscheidungen
+```
+
+## Drei Ebenen
+
+| Ebene | Zweck | Beispiele |
+|---|---|---|
+| 1. Root-README | Gesamtueberblick und Einstieg in die Spec. | `README.md` |
+| 2. Abschnitts-README | Lesefuehrung innerhalb einer Dokumentfamilie. | `01-wot-identity/README.md`, `02-wot-trust/README.md`, `03-wot-sync/README.md` |
+| 3. Detaildokumente | Normative Regeln, Formate, Flows und Verifikation. | `001-*`, `002-*`, Schemas, Test-Vektoren |
+
+Regel: Je tiefer die Ebene, desto normativer und detaillierter. Hoehere Ebenen duerfen erklaeren und verbinden, aber keine Detailregeln duplizieren oder ueberstimmen.
+
+## Arbeitsprinzipien
+
+1. Spec-Dokumente sind die Source of Truth.
+2. Abschnitts-READMEs verbinden Dokumente, statt sie zu kopieren.
+3. Unklare Regeln werden in den nummerierten Spec-Dokumenten korrigiert.
+4. Diagramme bleiben klein und beantworten eine konkrete Architekturfrage.
+5. Conformance-Profile sind Implementierungs-Claims, keine eigenen Architekturbausteine.
+6. Implementierungsdetails duerfen die Spec informieren, aber nicht heimlich ersetzen.
+
+## Architekturfragen Vor Dem TS-Mapping
+
+Diese Fragen muessen ausreichend klar sein, bevor die TypeScript-Architektur systematisch angepasst wird.
+
+| Bereich | Zu klaeren |
+|---|---|
+| Identity | Was ist Identity Core? Was ist nur Erweiterung? Welche Signaturpruefung liegt bei Identity, welche Semantik bei Trust oder Sync? |
+| Trust | Was ist Attestation-Semantik? Was ist Verification? Was gehoert nicht in Trust, z.B. Device-Key-Authority oder Sync-Zustellung? |
+| Sync | Was ist Protokoll, was Transport, was Broker? Was ist persistentes WoT-Objekt, was ephemerer Envelope? Was bleibt CRDT-/App-agnostisch? |
+| Extensions | Welche Semantik ist RLS/HMC-spezifisch? Welche Extension nutzt nur Trust, welche braucht Sync? |
+| Conformance | Welche Claims sind pruefbar? Welche Spec-Abschnitte, Schemas und Test-Vektoren belegen sie? |
+| TypeScript | Welche Module entsprechen Identity, Trust, Sync, Ports, Adapters und App? Welche aktuellen Module vermischen diese Grenzen? |
+
+## Reihenfolge
+
+1. Root-README auf Gesamtueberblick und Leseregeln stabilisieren.
+2. Abschnitts-README fuer Identity fertigstellen.
+3. Abschnitts-README fuer Trust erstellen.
+4. Abschnitts-README fuer Sync erstellen.
+5. RLS/HMC nur so weit strukturieren, wie es fuer Trust-/Sync-Grenzen noetig ist.
+6. Danach TypeScript-Mapping dokumentieren und erst dann groessere TS-Refactors fortsetzen.
+
+## Definition of Done Vor Groesseren TS-Refactors
+
+Vor einem groesseren TypeScript-Umbau sollte gelten:
+
+1. Root-README beschreibt die Dokumentfamilien und Leseregeln klar.
+2. Identity, Trust und Sync haben je eine knappe Abschnitts-README.
+3. Die wichtigsten Schichtgrenzen sind in der Spec verlinkt, nicht nur im Kopf bekannt.
+4. Offene Architektur-Kanten sind explizit benannt.
+5. Fuer das TS-Mapping ist klar, welche Spec-Familie welchem Modul-/Port-Bereich entspricht.
+6. `npm run validate` in `wot-spec` ist gruen.
+
+## Implementierungs-Kompass
+
+Das konkrete TypeScript-Mapping steht in [IMPLEMENTATION-ARCHITECTURE.md](IMPLEMENTATION-ARCHITECTURE.md). Zielrichtung:
+
+```txt
+protocol <- application <- react <- app
+ports <- application
+ports <- adapters
+```
+
+Dabei gilt:
+
+1. `protocol` bildet normative Spec-Objekte und Verifikation ab.
+2. `application` orchestriert Workflows, ohne Wire-Regeln neu zu definieren.
+3. `ports` beschreiben externe Faehigkeiten wie Storage, Crypto, Network, Broker oder CRDT.
+4. `adapters` implementieren Ports, duerfen aber keine Protokollautoritaet besitzen.
+5. UI/App-Code konsumiert Application-Use-Cases, nicht rohe Protokollinternals.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -109,7 +109,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 
 ## `wot-device-delegation@0.1` (geplant)
 
-`wot-device-delegation@0.1` ist ein geplantes Phase-2-Profil. Eine Implementierung ist konform, wenn sie zusaetzlich `wot-identity@0.1` und `wot-trust@0.1` erfuellt und die folgenden Faehigkeiten besitzt.
+`wot-device-delegation@0.1` ist ein geplantes Phase-2-Erweiterungsprofil in der Identity-Dokumentfamilie, aber nicht Teil von `wot-identity@0.1`. Eine Implementierung ist konform, wenn sie zusaetzlich `wot-identity@0.1` und `wot-trust@0.1` erfuellt und die folgenden Faehigkeiten besitzt.
 
 - DeviceKeyBinding-JWS mit `typ: "wot-device-key-binding+jwt"` erzeugen und verifizieren.
 - `deviceKid`, `sub` und `devicePublicKeyMultibase` konsistent pruefen.

--- a/IMPLEMENTATION-ARCHITECTURE.md
+++ b/IMPLEMENTATION-ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Implementierungs-Architektur
+
+> **Nicht normativ:** Dieses Dokument beschreibt das Ziel-Mapping fuer die TypeScript-Referenzimplementierung. Normative Anforderungen stehen in den nummerierten Spec-Dokumenten, Schemas, Test-Vektoren und `CONFORMANCE.md`.
+
+## Ziel
+
+Die TypeScript-Implementierung soll die Spec-Grenzen sichtbar machen, statt Protokollregeln, App-Workflows, UI und Infrastruktur in einem Importraum zu vermischen.
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"background": "transparent", "primaryColor": "#f8fafc", "primaryTextColor": "#111827", "primaryBorderColor": "#64748b", "lineColor": "#94a3b8", "tertiaryColor": "#f8fafc", "fontFamily": "system-ui, sans-serif"}}}%%
+flowchart LR
+  App[app]
+  React[react]
+  Application[application]
+  Protocol[protocol]
+  Ports[ports]
+  Adapters[adapters]
+
+  App --> React
+  React --> Application
+  Application --> Protocol
+  Application --> Ports
+  Adapters --> Ports
+```
+
+Der Pfeil zeigt zur erlaubten Abhaengigkeit: `application` darf `protocol` verwenden, aber `protocol` darf `application` nicht kennen. `adapters` implementieren `ports`; `application` orchestriert gegen `ports` und nicht gegen konkrete Adapter.
+
+## Layer-Regeln
+
+| Layer | Aufgabe | Darf kennen | Darf nicht kennen | Aktueller Anker |
+|---|---|---|---|---|
+| `protocol` | Deterministische Spec-Objekte, Encoding, Signatur-/Payload-Verifikation, Testvektor-nahe Funktionen. | Kleine Crypto-Ports, reine Typen. | Storage, Network, CRDT, React, App-Services. | `web-of-trust/packages/wot-core/src/protocol/` |
+| `application` | Use-Cases und Workflows: Identity, Verification, Attestations, Spaces, Sync-Orchestrierung. | `protocol`, `ports`, reine Domain-Typen. | Browser APIs, konkrete Datenbanken, konkrete Broker/CRDT-Adapter, UI. | `web-of-trust/packages/wot-core/src/application/`, Teile von `src/services/` |
+| `ports` | Interfaces fuer Storage, Crypto, Network, Discovery, Replication, Outbox, Authorization, Clock/Random. | Reine Typen aus `protocol` oder Domain-Typen. | Adapter-Implementierungen, UI, Produktlogik. | `web-of-trust/packages/wot-core/src/ports/`, aktuell auch `src/adapters/interfaces/` |
+| `adapters` | Konkrete Implementierungen fuer Browser, Server, CRDTs, Broker, Profil-Service, Vault oder lokale Persistenz. | `ports`, ggf. `protocol` fuer Wire-Objekte. | `application`-Use-Cases als harte Abhaengigkeit, UI-State als Protokollautoritaet. | `src/adapters/`, `packages/adapter-yjs/`, `packages/adapter-automerge/`, App-lokale Adapter |
+| `react` | Wiederverwendbare Hooks und Contexts ueber Application-Use-Cases. | `application`-Interfaces, View-Model-Typen. | Rohe Protokollinternals, konkrete Adapter, Browser-Persistenz ausserhalb von App-Wiring. | Derzeit app-lokal in `apps/demo/src/hooks/` und `apps/demo/src/context/` |
+| `app` | Runtime Composition, Routing, Produkt-UI, Konfiguration, Deployment-spezifisches Wiring. | `react`, `application`, konkrete Adapter an der Composition Root. | Eigene Protokollregeln oder alternative Verifikation. | `apps/demo/src/runtime/appRuntime.ts`, `apps/demo/src/App.tsx`, `apps/demo/src/pages/` |
+| Server-Infrastruktur | Referenzdienste fuer Sync/Discovery/Vault. | Protokollobjekte, Ports, Server-Adapter. | Normative App-Semantik, UI-Annahmen. | `packages/wot-relay/`, `packages/wot-profiles/`, `packages/wot-vault/`, `packages/wot-cli/` |
+
+## Spec-Familien zu TypeScript
+
+| Spec-Familie | Primaere TS-Orte | Zielgrenze |
+|---|---|---|
+| WoT Identity | `src/protocol/identity/`, `src/protocol/crypto/`, `src/application/identity/`, `src/ports/identity-vault.ts`, `src/protocol-adapters/web-crypto.ts` | Key-Derivation, DID und JWS bleiben in `protocol`; Seed-Speicherung und Session-Workflow gehoeren zu `application` plus `ports`. |
+| WoT Trust | `src/protocol/trust/`, `src/application/attestations/`, `src/application/verification/` | VC-JWS-Verifikation gehoert zu `protocol`; Erzeugen, Importieren, Anzeigen und Zustellen gehoeren zu `application` und App. |
+| WoT Sync | `src/protocol/sync/`, `src/application/spaces/`, `src/services/`, `src/ports/spaces.ts`, `packages/adapter-yjs/`, `packages/adapter-automerge/`, `packages/wot-relay/` | Log-/Capability-/Encryption-Objekte gehoeren zu `protocol`; Sync-State-Machine und Workflows zu `application`; CRDT, Broker und Persistenz zu `adapters`. |
+| Discovery/Profile | `src/adapters/discovery/`, `src/services/ProfileService.ts`, `packages/wot-profiles/` | Profil-Service-Verifikation muss Spec-Objekte nutzen; HTTP und Cache bleiben Adapter-/Service-Infrastruktur. |
+| RLS/HMC Extensions | Aktuell nur teilweise in `src/protocol/trust/sd-jwt-vc.ts` und App-/Extension-Code | Extension-Semantik darf Trust/Sync nutzen, aber nicht in Identity oder Sync-Core wandern. |
+
+## Aktuelle TypeScript-Landkarte
+
+| Paket/Bereich | Aktuelle Rolle | Zielrolle |
+|---|---|---|
+| `@web_of_trust/core` | Mischt heute Protocol Core, Application Workflows, Ports, Services, Adapter-Interfaces, Browser-Adapter und Debug-Hilfen im Root-Export. | Logischer Kern mit klaren Entry-Points fuer `protocol`, `application`, `ports` und explizite Adapter-Submodule. |
+| `packages/wot-core/src/protocol/` | Bereits als Spec-nahe Protocol-Core-Schicht angelegt. | Bleibt die deterministische Protokollbasis und orientiert sich an `wot-spec` Test-Vektoren. |
+| `packages/wot-core/src/application/` | Workflows fuer Identity, Verification, Attestations und Spaces. | App-nutzbare Use-Cases, die gegen Ports orchestrieren. |
+| `packages/wot-core/src/services/` | Gemischte Orchestrierung und Infrastrukturhilfen, z.B. Profile, Encrypted Sync, Group Keys, Vault Push. | Aufteilen in Application-Use-Cases oder Adapter-/Infra-Services. |
+| `packages/wot-core/src/adapters/interfaces/` | Effektiv viele Ports, aber unter Adapter-Pfad. | Nach `src/ports/` konsolidieren. |
+| `packages/wot-core/src/adapters/` | Browser-/Memory-/HTTP-/WebSocket-/Storage-Implementierungen im Core-Paket. | Konkrete Adapter klar von Application/Protocol trennen; ggf. eigene Adapter-Entry-Points oder Pakete. |
+| `packages/adapter-yjs/` | Yjs Personal Doc, Storage, Sync und Replication. | CRDT-/DocStore-/Replication-Adapter, nicht normative Sync-State-Machine-Autoritaet. |
+| `packages/adapter-automerge/` | Automerge Personal Doc, Replication, Storage und Outbox. | CRDT-/DocStore-/Replication-Adapter mit denselben Port-Grenzen wie Yjs. |
+| `apps/demo/` | App, React, Runtime Composition und app-lokale Adapter. | Composition Root plus Produkt-UI; Hooks konsumieren Application-Use-Cases statt rohe Protokollinternals. |
+| `packages/wot-relay/` | Broker/Relay. | Referenzimplementierung fuer Sync 003 Broker-Verhalten. |
+| `packages/wot-profiles/` | Profil-Service. | Referenzimplementierung fuer Sync 004 Profil-Service. |
+| `packages/wot-vault/` | Vault-Service und vendored `wot-core-dist`. | Externe Infrastruktur; nach Core-Aenderungen `packages/wot-vault/docker-build.sh` nutzen, um `wot-core-dist` zu refreshen. |
+| `packages/wot-cli/` | CLI und Server-/Storage-Integration. | Referenz-Consumer fuer Ports und Adapter ausserhalb der Demo-App. |
+
+## Import-Regeln
+
+| Von | Erlaubt | Nicht erlaubt |
+|---|---|---|
+| `protocol` | Reine Hilfsfunktionen, kleine Ports, lokale Typen. | `application`, `services`, `adapters`, React, App-Code. |
+| `application` | `protocol`, `ports`, Domain-Typen. | Konkrete Adapter, `window`, `document`, `indexedDB`, direkte WebSocket-/HTTP-Implementierung. |
+| `ports` | Reine Typen. | Adapter-Implementierungen oder Workflow-Code. |
+| `adapters` | `ports`, Wire-/Payload-Typen aus `protocol`, Plattform-APIs. | UI-State oder Application-Use-Cases als notwendige Abhaengigkeit. |
+| `react` | Application-Use-Cases, View-Models. | Direkte Protokoll-Erzeugung/-Verifikation ausserhalb bewusst technischer Debug-Views. |
+| `app` | Alles an der Composition Root, aber nur dort. | Eigene alternative Protokollregeln. |
+
+## Bekannte Abweichungen
+
+Diese Punkte sind Implementierungsdebt, keine Spec-Aussagen.
+
+| Punkt | Aktueller Zustand | Ziel |
+|---|---|---|
+| Root-Export | `packages/wot-core/src/index.ts` exportiert Typen, Protocol, Application, Ports, Services, Adapter und Debug-Hilfen zusammen. | Oeffentliche API in Schichten gliedern; Apps importieren bevorzugt aus klaren Namespaces. |
+| Ports | Nur wenige Interfaces liegen in `src/ports/`; viele liegen in `src/adapters/interfaces/`. | Alle Ports in `src/ports/`, Adapter implementieren sie. |
+| Browser-Adapter im Core | `HttpDiscoveryAdapter`, `WebSocketMessagingAdapter`, IndexedDB-/LocalStorage-Adapter und Debug-Storage liegen im Core-Paket. | Konkrete Browser-/Storage-Adapter aus Application-Grenze herausziehen. |
+| Services | Teile von `src/services/` sind Application-Orchestrierung, andere Infrastruktur. | Services klassifizieren und verschieben: Use-Case nach `application`, Infrastruktur nach `adapters` oder Server-Pakete. |
+| Crypto-Duplikation | Es gibt `src/protocol/crypto/` und `src/crypto/`. | Ein Spec-naher Protocol-Crypto-Kern; doppelte Hilfen entfernen oder eindeutig zuordnen. |
+| Adapter-Abhaengigkeiten | CRDT-Adapter importieren teilweise Core-Services wie `GroupKeyService`, `EncryptedSyncService` oder `VaultPushScheduler`. | Adapter gegen Ports und Protokolltypen implementieren; Application komponiert Services. |
+| Demo-Importe | Hooks und Services in `apps/demo/` importieren teilweise `protocol` oder Signaturhelfer direkt. | React/App konsumiert Workflows; direkte Protocol-Imports nur fuer Debug-/Interop-Oberflaechen. |
+| React-Schicht | Es gibt noch kein wiederverwendbares React-Paket. | Erst extrahieren, wenn ein zweiter Consumer die Hooks/Contexts braucht. |
+
+## Migrationsreihenfolge
+
+1. Spec-Leseschicht und Conformance-Artefakte gruen halten.
+2. Layer-Entry-Points dokumentieren und neue Imports daran ausrichten.
+3. Adapter-Interfaces aus `src/adapters/interfaces/` nach `src/ports/` konsolidieren.
+4. `src/services/` in Application-Use-Cases und Infrastruktur-Adapter aufteilen.
+5. Browser-/Storage-/Network-Adapter aus dem Core-Root-Export entfernen oder explizit als Adapter-Entry-Points fuehren.
+6. Yjs und Automerge auf CRDT-/DocStore-/Replication-Adapter begrenzen; die normative Sync-Reihenfolge bleibt in Application/Protocol abgebildet.
+7. Demo-Hooks und App-Services auf Application-Use-Cases umstellen.
+8. Optionales React-Paket erst erstellen, wenn Wiederverwendung den Split rechtfertigt.
+
+## Definition of Done Fuer Einen Groesseren TS-Umbau
+
+1. `protocol` reproduziert die relevanten `wot-spec` Test-Vektoren und importiert keine App-/Adapter-Schichten.
+2. `application` nutzt Ports fuer Storage, Network, Discovery, Replication und Crypto-Umgebung.
+3. Konkrete Adapter besitzen keine Protokollautoritaet und duerfen bekannte gueltige Protokollobjekte nicht durch lokale Heuristiken ersetzen.
+4. React-Hooks konsumieren Use-Cases oder View-Models, nicht rohe Wire-Objekte.
+5. `apps/demo/src/runtime/appRuntime.ts` oder ein aequivalenter Composition-Root verdrahtet konkrete Adapter.
+6. `npm run validate` in `wot-spec` bleibt gruen.
+7. Relevante `web-of-trust` Checks laufen fuer geaenderte Pakete, mindestens `pnpm --filter @web_of_trust/core test`, `typecheck` und `build` bei Core-Aenderungen.

--- a/README.md
+++ b/README.md
@@ -6,13 +6,47 @@ Ein Protokoll für dezentrale Vertrauensnetzwerke basierend auf echten Begegnung
 
 Zwei Menschen treffen sich, verifizieren ihre Identität, und stellen sich gegenseitig signierte Aussagen aus — kryptographisch verifizierbar, offline-fähig, ohne zentrale Instanz.
 
-Das Protokoll besteht aus drei Schichten:
+Die Spezifikation ist die neutrale Protokollquelle. Referenzimplementierungen informieren sie, ersetzen sie aber nicht.
 
-**WoT Identity** — Dezentrale Identität (DID), Schlüsselableitung, Signaturen, JCS/JWS und DID-Resolution.
+## Wie diese Spec gelesen wird
 
-**WoT Trust** — Signierte Aussagen (W3C Verifiable Credentials) und ein Challenge-Response-Verifikationsverfahren für physische Begegnungen.
+| Ebene | Zweck |
+|---|---|
+| Diese README | Gesamtueberblick: Was ist WoT, welche Dokumentfamilien gibt es, wo beginnt man? |
+| Abschnitts-READMEs | Lesefuehrung innerhalb einer Dokumentfamilie, z.B. [WoT Identity](01-wot-identity/README.md). |
+| Nummerierte Dokumente | Normative Detail-Spezifikation mit Regeln, Formaten und Verifikationsablaeufen. |
 
-**WoT Sync** — Verschlüsselter Local-First Sync mit E2EE, Append-only Logs und Broker-as-Peer.
+[Schemas](schemas/) und [Test-Vektoren](test-vectors/) machen Formate und Krypto-Werte pruefbar. [CONFORMANCE](CONFORMANCE.md) definiert abgeleitete Implementierungs-Claims wie `wot-identity@0.1`. [Forschung](#forschung) ist nicht normativ.
+
+Wenn eine Architektur- oder Implementierungsarbeit eine unklare Regel findet, wird die normative Spec-Datei korrigiert. Uebersichten ueberstimmen die Spec nicht.
+
+## Spec-Landkarte
+
+```mermaid
+%%{init: {"theme": "base", "themeVariables": {"background": "transparent", "primaryColor": "#f8fafc", "primaryTextColor": "#111827", "primaryBorderColor": "#64748b", "lineColor": "#94a3b8", "tertiaryColor": "#f8fafc", "fontFamily": "system-ui, sans-serif"}}}%%
+flowchart TD
+  Identity[WoT Identity]
+  Trust[WoT Trust]
+  Sync[WoT Sync]
+  RLS[RLS Extension]
+  HMC[HMC Extension]
+
+  Identity --> Trust
+  Identity --> Sync
+  Trust --> RLS
+  Trust --> HMC
+  Sync --> HMC
+```
+
+| Dokumentfamilie | Kurzrolle | Einstieg |
+|---|---|---|
+| WoT Identity | Keys, DID, JWS/JCS, DID-Resolution. | [01-wot-identity/README.md](01-wot-identity/README.md) |
+| WoT Trust | Attestations und reale Verifikation. | [02-wot-trust/README.md](02-wot-trust/README.md) |
+| WoT Sync | Verschluesselter Local-First-Sync, Broker, Inbox, Spaces, Personal Doc. | [03-wot-sync/README.md](03-wot-sync/README.md) |
+| RLS Extension | App-spezifische Badge-Erweiterung. | [04-rls-extensions/](04-rls-extensions/) |
+| HMC Extension | Trust-Scores, Trust-Lists, Transactions, Gossip. | [05-hmc-extensions/](05-hmc-extensions/) |
+
+## Standards
 
 WoT definiert keine neuen Standards — es kombiniert bestehende Standards und bewusst begrenzte Kompatibilitaetsprofile:
 
@@ -29,27 +63,13 @@ WoT definiert keine neuen Standards — es kombiniert bestehende Standards und b
 | [X25519](https://datatracker.ietf.org/doc/html/rfc7748) (RFC 7748) | ECDH Key Agreement (ECIES) |
 | [AES-256-GCM](https://csrc.nist.gov/publications/detail/sp/800-38d/final) (NIST) | Symmetrische Verschlüsselung |
 
-## Architektur
-
-```
-┌─────────────────────────────────────────┐
-│  Apps (WoT App, Real Life, Human Money) │
-├──────────────────┬──────────────────────┤
-│  RLS Extension   │  HMC Extension       │
-├──────────────────┴──────────────────────┤
-│  WoT Sync (E2EE, Logs, Broker, Groups)  │
-├─────────────────────────────────────────┤
-│  WoT Trust (Attestations, Verification) │
-├─────────────────────────────────────────┤
-│  WoT Identity (Keys, DID, JWS, resolve) │
-└─────────────────────────────────────────┘
-```
-
 ## Governance
 
 | Dokument | Beschreibung |
 |----------|-------------|
 | [ROADMAP](ROADMAP.md) | Milestones und naechste Arbeitsbloecke |
+| [ARCHITECTURE](ARCHITECTURE.md) | Arbeitskompass fuer Spec-Leseschicht, Architekturfragen und TypeScript-Mapping |
+| [IMPLEMENTATION-ARCHITECTURE](IMPLEMENTATION-ARCHITECTURE.md) | Nicht-normativer TypeScript-Mapping-Kompass fuer die Referenzimplementierung |
 | [VERSIONING](VERSIONING.md) | Release-Versionen, Spec-Profile, Wire-Versionen |
 | [CHANGELOG](CHANGELOG.md) | Nachvollziehbare Aenderungen zwischen Releases |
 | [CONFORMANCE](CONFORMANCE.md) | Anforderungen fuer konforme Implementierungen |
@@ -64,16 +84,20 @@ WoT definiert keine neuen Standards — es kombiniert bestehende Standards und b
 
 Was jede Implementierung braucht, die WoT-DIDs, Signaturen oder DID-Dokumente verwendet.
 
+Einstieg: [WoT Identity README](01-wot-identity/README.md).
+
 | # | Dokument | Beschreibung |
 |---|----------|-------------|
 | 001 | [Identität und Schlüsselableitung](01-wot-identity/001-identitaet-und-schluesselableitung.md) | BIP39 → HKDF → Ed25519 + X25519 Schlüsselpaare |
 | 002 | [Signaturen und Verifikation](01-wot-identity/002-signaturen-und-verifikation.md) | Ed25519, JWS, JCS, SHA-256 |
 | 003 | [DID-Dokument und Resolution](01-wot-identity/003-did-resolution.md) | DID-Methoden-agnostisch, resolve()-Interface, did:key + did:webvh |
-| 004 | [Device-Key-Delegation](01-wot-identity/004-device-key-delegation.md) | Geplante Phase-2-Erweiterung: DeviceKeyBinding und Delegated-Attestation-Bundle |
+| 004 | [Device-Key-Delegation](01-wot-identity/004-device-key-delegation.md) | Geplantes Phase-2-Erweiterungsprofil der Identity-Dokumentfamilie; nicht Teil von `wot-identity@0.1` |
 
 ### WoT Trust — Vertrauenssemantik
 
 Was Apps brauchen, die Attestations und reale Verifikation verwenden.
+
+Einstieg: [WoT Trust README](02-wot-trust/README.md).
 
 | # | Dokument | Beschreibung |
 |---|----------|-------------|
@@ -83,6 +107,8 @@ Was Apps brauchen, die Attestations und reale Verifikation verwenden.
 ### WoT Sync — Verschlüsselte Infrastruktur
 
 Nicht WoT-spezifisch — jede Local-First-App könnte das nutzen.
+
+Einstieg: [WoT Sync README](03-wot-sync/README.md).
 
 | # | Dokument | Beschreibung |
 |---|----------|-------------|

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -30,7 +30,7 @@ Implementierungen geben an, welche Profile sie unterstuetzen:
 | `wot-identity@0.1` | Identitaet, Key-Derivation, Signaturen, JWS/JCS, DID-Resolution |
 | `wot-trust@0.1` | Attestations, Verification-Attestations, QR-/Nonce-Verifikation |
 | `wot-sync@0.1` | Verschluesselung, Append-only Log, Broker, Discovery, Gruppen, Personal Doc |
-| `wot-device-delegation@0.1` | Geplante Phase-2-Erweiterung: DeviceKeyBinding und delegierte Attestations |
+| `wot-device-delegation@0.1` | Geplantes Phase-2-Erweiterungsprofil der Identity-Dokumentfamilie: DeviceKeyBinding und delegierte Signaturen |
 | `wot-rls@0.1` | Real-Life-Stack-spezifische Erweiterungen |
 | `wot-hmc@0.1` | Human-Money-Core-spezifische Erweiterungen |
 

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -80,7 +80,7 @@
       ]
     },
     "wot-device-delegation@0.1": {
-      "description": "Geplante Phase-2-Erweiterung: DeviceKeyBinding und Delegated-Attestation-Bundle.",
+      "description": "Geplantes Phase-2-Erweiterungsprofil der Identity-Dokumentfamilie: DeviceKeyBinding und Delegated-Attestation-Bundle.",
       "requires": ["wot-identity@0.1", "wot-trust@0.1"],
       "spec_documents": ["01-wot-identity/004-device-key-delegation.md"],
       "schemas": [

--- a/research/autonomous-pipeline.md
+++ b/research/autonomous-pipeline.md
@@ -1,0 +1,428 @@
+# Autonomous Spec-Driven Development Pipeline
+
+> **Nicht normativ:** Dieses Dokument ist Hintergrund, Analyse oder Planung. Normative Anforderungen stehen in den Spec-Dokumenten und in `CONFORMANCE.md`.
+
+*Stand: 2. Mai 2026*
+
+## Kontext
+
+Die Web-of-Trust-Entwicklung laeuft seit Q4 2025 weitgehend spec-driven: normative Dokumente, Test-Vektoren, Schemas und ein Conformance-Manifest (`conformance/manifest.json`) definieren, was korrekt ist. Die TypeScript-Referenzimplementierung (`web-of-trust`) wird gegen diese Spec gebaut.
+
+Der Flaschenhals ist die Orchestrierung. Heute startet, steuert und reviewed ein Mensch (Anton) jeden Arbeitsschritt manuell:
+
+```
+Anton denkt: "Was ist als Naechstes dran?"
+Anton sagt zu Claude: "Implementier das."
+Anton sagt zu Codex: "Bau das."
+Anton sagt zu Claude: "Review mal was Codex gemacht hat."
+Anton merged.
+```
+
+Dieses Dokument beschreibt, wie diese Schleife automatisiert wird, sodass Antons Rolle sich vom Ausfuehren zum Entscheiden verschiebt.
+
+Operative Umsetzung: Die konkrete Level-1-Basis fuer die TypeScript-Referenzimplementierung liegt in `web-of-trust/docs/PROJECT-FLOW.md` und `web-of-trust/docs/automation/`. Dort werden Task-Contract-Format, Review-Rollen und das lokale PR-Review-Paket-Script beschrieben. Dieses Research-Dokument bleibt die Pipeline-Vision; die `web-of-trust`-Dokumente beschreiben die ausfuehrbare Projektschicht.
+
+## Grundannahme
+
+Die Spezifikation ist die Programmiersprache fuer die Agents. Je praeziser die Spec, desto autonomer koennen Claude und Codex arbeiten:
+
+| Spec-Praezision | Agent-Autonomie | Beispiel |
+|---|---|---|
+| Test-Vektor (Input + erwartetes Output) | Vollstaendig autonom | `phase-1-interop.json` |
+| JSON Schema + MUST/SHOULD-Regeln | Weitgehend autonom | `attestation-vc-payload.schema.json` |
+| Prosa mit klaren Anforderungen | Braucht gelegentlich Rueckfrage | `001-identitaet-und-schluesselableitung.md` |
+| Vage Prosa oder fehlend | Nicht autonom moeglich | Zurueck an Mensch |
+
+Die Pipeline wird daher umso leistungsfaehiger, je mehr Spec-Abschnitte durch Test-Vektoren und Schemas abgedeckt sind.
+
+## Architektur
+
+```
+MENSCHLICHE EBENE
+  Anton + Team: Spec schreiben, Architektur-Entscheidungen,
+  Merge-Gate, Richtung vorgeben
+       |                              ^
+       | pusht Spec                   | approved / rejected
+       v                              |
+SPEC REPOSITORY (wot-spec/)           |
+  01-wot-identity/                    |
+  02-wot-trust/                       |
+  03-wot-sync/                        |
+  test-vectors/                       |
+  schemas/                            |
+  conformance/manifest.json           |
+  ROADMAP.md                          |
+       |                              |
+       v                              |
+ORCHESTRIERUNG                        |
+  Scheduled Agents + GitHub Actions   |
+       |                              |
+       +---> Conformance-Waechter ----+
+       +---> Gap-Analyse              |
+       +---> Task-Generierung         |
+       +---> Implementierung (Claude / Codex)
+       +---> Cross-Review             |
+       +---> Human Gate --------------+
+```
+
+## Die sieben Phasen
+
+### Phase 0: Conformance-Waechter
+
+**Frequenz:** Taeglich, plus bei jedem Push auf `main`
+
+**Agent:** Claude `/schedule`
+
+**Aufgabe:**
+1. `npm run validate` in `wot-spec/` ausfuehren (Schemas, Vektoren, Manifest)
+2. `pnpm --filter @web_of_trust/core test` in `web-of-trust/` ausfuehren
+3. Ergebnis als GitHub Issue zusammenfassen, falls Regressionen
+
+**Trigger-Bedingung:** Nur bei Rot wird ein Issue erstellt. Gruene Laeufe erzeugen hoechstens einen kurzen Statuskommentar auf einem bestehenden Tracking-Issue.
+
+**Output-Schema:**
+```
+## Conformance Report — {Datum}
+
+### wot-spec validate
+- schemas: {pass|fail} ({n} schemas)
+- test-vectors: {pass|fail} ({n} vectors)
+- conformance: {pass|fail}
+
+### web-of-trust tests
+- @web_of_trust/core: {pass|fail} ({n}/{m} tests)
+- typecheck: {pass|fail}
+- build: {pass|fail}
+
+### Regressions
+- {Liste der neu fehlgeschlagenen Tests mit Commit-Referenz}
+```
+
+### Phase 1: Gap-Analyse
+
+**Frequenz:** Woechentlich (Montag), plus bei Spec-Aenderungen
+
+**Agent:** Claude `/schedule`
+
+**Aufgabe:**
+1. `conformance/manifest.json` einlesen — welche Profile, welche Spec-Dokumente, welche Test-Vektoren
+2. Fuer jedes Conformance-Profil pruefen:
+   - Existieren alle referenzierten Test-Vektoren?
+   - Haben alle Test-Vektor-Sektionen entsprechende Tests in `web-of-trust`?
+   - Existieren alle referenzierten Schemas?
+   - Gibt es MUST/SHOULD-Anforderungen in der Spec ohne Test-Vektor?
+3. `ROADMAP.md` Milestone-Status aktualisieren
+4. Ergebnis als GitHub Issue mit Label `gap-analysis`
+
+**Konkret fuer den aktuellen Stand:**
+
+Das Conformance-Manifest definiert 6 Profile (`wot-identity@0.1`, `wot-trust@0.1`, `wot-sync@0.1`, `wot-device-delegation@0.1`, `wot-rls@0.1`, `wot-hmc@0.1`). Die Gap-Analyse prueft fuer jedes Profil den Deckungsgrad zwischen Spec-Anforderungen, Schemas, Test-Vektoren und Implementierung.
+
+**Output-Schema:**
+```
+## Gap Analysis — {Datum}
+
+### Per Conformance-Profil
+
+#### wot-identity@0.1
+- Spec-Dokumente: 3/3 vorhanden
+- Schemas: 1/1 vorhanden
+- Test-Vektor-Sektionen: identity (impl: ja), did_resolution (impl: ja)
+- Offene MUST-Anforderungen ohne Vektor: {Liste}
+
+#### wot-sync@0.1
+- Test-Vektor-Sektionen: ecies (impl: ja), log_entry_jws (impl: teilweise), ...
+- Offene MUST-Anforderungen ohne Vektor: {Liste}
+
+### Neue Gaps seit letzter Analyse
+- {Liste mit Spec-Referenz und Dateipfad}
+
+### Priorisierte naechste Schritte
+1. {Hoechste Prioritaet mit Begruendung}
+2. ...
+```
+
+### Phase 2: Task-Generierung
+
+**Trigger:** Nach jeder Gap-Analyse, oder manuell durch Anton
+
+**Agent:** Claude (synchron oder `/schedule`)
+
+**Aufgabe:** Gaps in ausfuehrbare, atomare Tasks zerlegen.
+
+**Regeln fuer einen guten Task:**
+- **Ein Task = ein PR.** Nicht groesser als ein zusammenhaengendes Feature oder eine Korrektur.
+- **Spec-Referenz ist Pflicht.** Jeder Task referenziert exakt welche Spec-Abschnitte, Test-Vektoren oder Schema-Dateien er adressiert.
+- **Done-Kriterien sind maschinenlesbar.** Welche Tests muessen gruen sein? Welche Validierungen muessen laufen?
+- **Constraints sind explizit.** Welche Dateien duerfen geaendert werden? Welche Interfaces sind stabil? Welche Layer-Grenzen gelten?
+- **Komplexitaet ist geschaetzt.** `small` (< 100 Zeilen), `medium` (100-500), `large` (> 500, sollte gesplittet werden).
+
+**Task-Format (GitHub Issue):**
+```
+## Task: {Titel}
+
+**Spec Reference:** {Dokument} Section {N}, Test-Vektoren: {Liste}
+**Conformance Profile:** {Profil aus manifest.json}
+
+**Scope:**
+- {Dateipfade die geaendert werden}
+
+**Done Criteria:**
+- [ ] {Konkrete Test- oder Validierungsbedingung}
+- [ ] `pnpm --filter @web_of_trust/core test` gruen
+- [ ] `pnpm --filter @web_of_trust/core typecheck` gruen
+
+**Constraints:**
+- {Layer-Grenzen, Interface-Stabilitaet, etc.}
+
+**Complexity:** small | medium | large
+**Labels:** agent-task, ready, {conformance-profile}
+```
+
+**Menschliches Gate:** Tasks mit Complexity `large` oder unklarer Spec bekommen Label `needs-human` statt `ready`.
+
+### Phase 3: Implementierung
+
+**Trigger:** GitHub Issue mit Labels `agent-task` + `ready`
+
+**Agents:** Claude und Codex arbeiten parallel aus dem Task-Pool.
+
+**Routing — wer bekommt welchen Task:**
+
+| Kriterium | Agent | Begruendung |
+|---|---|---|
+| Neuen Test-Vektor implementieren | Codex | Klar eingegrenzt: Input/Output gegeben |
+| Neues Schema validieren | Codex | Mechanisch, Schema liegt vor |
+| Spec-Section erstmalig implementieren | Codex | Fokussiert, spec-nah, schnell |
+| Refactoring / Layer-Migration | Claude | Architektur-Kontext, Cross-Cutting |
+| Bug aus Conformance-Regression | Codex | Klar eingegrenzt durch fehlschlagenden Test |
+| Neuen Test-Vektor *schreiben* | Claude | Braucht Spec-Interpretation |
+| Adapter auf neues Port-Interface umstellen | Codex | Mechanisch, Interface definiert |
+| Spec-Ambiguitaet → Implementation erfordert Entscheidung | Keiner | Zurueck an Anton |
+
+**Ablauf pro Agent:**
+
+1. Agent liest den Task-Issue komplett (Spec-Referenz, Scope, Done Criteria, Constraints)
+2. Agent erstellt Branch: `agent/{claude|codex}/{issue-number}-{slug}`
+3. Agent implementiert innerhalb des definierten Scope
+4. Agent fuehrt Done-Criteria-Checks lokal aus (Tests, Typecheck, Build)
+5. Agent erstellt PR mit:
+   - Referenz auf Task-Issue (`Closes #{issue}`)
+   - Zusammenfassung der Aenderungen
+   - Ergebnis der Done-Criteria-Checks
+6. PR bekommt Label `needs-cross-review`
+
+**Fehlerfall:** Wenn ein Agent die Done-Kriterien nicht erfuellen kann (Test bleibt rot, Spec unklar, Scope zu gross), erstellt er einen Kommentar auf dem Task-Issue mit einer Analyse statt eines PRs. Das Issue bekommt Label `blocked`.
+
+### Phase 4: Cross-Review
+
+**Trigger:** PR mit Label `needs-cross-review`
+
+**Ablauf:**
+
+```
+PR erstellt von Agent A
+  |
+  v
+GitHub Action erkennt Label "needs-cross-review"
+  |
+  v
+Agent B wird getriggert (Claude reviewt Codex, Codex reviewt Claude)
+  |
+  +-- Prueft:
+  |   1. Spec-Konformitaet: Stimmt die Implementierung mit der
+  |      referenzierten Spec-Section und den Test-Vektoren ueberein?
+  |   2. Layer-Grenzen: Werden die Import-Regeln aus
+  |      IMPLEMENTATION-ARCHITECTURE.md eingehalten?
+  |   3. Security: Crypto korrekt, keine Injection, OWASP-konform?
+  |   4. Done Criteria: Sind alle Checks aus dem Task-Issue erfuellt?
+  |   5. Konsistenz: Passt der PR zur restlichen Codebase?
+  |
+  v
+Review-Ergebnis als PR-Kommentar
+  |
+  +-- Approve          --> Label "ready-for-human"
+  +-- Request Changes  --> Agent A ueberarbeitet, neuer Review-Zyklus
+  +-- Uneinigkeit      --> Label "needs-discussion", Summary fuer Anton
+```
+
+**Review-Format:**
+```
+## Cross-Review von {Agent}
+
+**Spec Conformance:** {pass|fail} — {Details}
+**Layer Boundaries:** {pass|fail} — {Details}
+**Security:** {pass|warn|fail} — {Details}
+**Done Criteria:** {pass|fail} — {Checkliste}
+**Consistency:** {pass|warn} — {Details}
+
+**Verdict:** approve | request-changes | needs-discussion
+**Summary:** {1-2 Saetze}
+```
+
+### Phase 5: Human Gate
+
+**Trigger:** PR mit Label `ready-for-human` oder `needs-discussion`
+
+**Antons reduzierter Aufwand:**
+
+| PR-Typ | Aktion | Zeitaufwand |
+|---|---|---|
+| `ready-for-human` (beide Agents approved) | Kurz draufschauen, mergen | ~30 Sekunden |
+| `needs-discussion` (Agents uneinig) | Lesen, entscheiden, kommentieren | ~5 Minuten |
+| `blocked` (Agent kam nicht weiter) | Spec klaeren oder Task anpassen | ~15 Minuten |
+
+**Fuer Teammitglieder (Sebastian, Tillmann):** Sie sehen dieselben PRs und koennen kommentieren. Agents reagieren auf Kommentare von jedem Teammitglied, nicht nur von Anton.
+
+**Geschaetzter Tagesaufwand:** 15-30 Minuten statt mehrerer Stunden manueller Steuerung.
+
+### Phase 6: Merge und Feedback-Loop
+
+**Nach dem Merge:**
+
+1. CI laeuft (existierende `ci.yml`)
+2. Conformance-Waechter (Phase 0) bestaetigt, dass nichts kaputt ist
+3. Task-Issue wird geschlossen
+4. Falls die Implementierung Spec-Luecken aufgedeckt hat: neues Issue in `wot-spec/` mit Label `spec-gap`
+
+**Feedback-Loop zurueck in die Spec:**
+
+```
+Implementierung deckt Ambiguitaet auf
+  |
+  v
+Agent erstellt Issue in wot-spec/ mit:
+  - Betroffener Spec-Abschnitt
+  - Was unklar ist
+  - Vorschlag (falls moeglich)
+  - Label: spec-gap
+  |
+  v
+Anton/Team entscheidet
+  |
+  v
+Spec-Aenderung --> Neuer Gap-Analyse-Zyklus
+```
+
+## Ressourcen und Kontingente
+
+| Ressource | Verfuegbar | Einsatz |
+|---|---|---|
+| Claude Max | Unbegrenzte Messages | Gap-Analyse, Task-Generierung, Reviews, Architektur-Tasks |
+| ChatGPT Pro (Codex) | Kontingent-basiert | Fokussierte Implementierungstasks, mechanische Korrekturen |
+| GitHub Actions | CI-Minuten (2000/Monat Free, mehr bei Pro) | Cross-Review-Trigger, Conformance-Checks, PR-Automatisierung |
+| `/schedule` (Claude Code) | Cron-basierte Agents | Conformance-Waechter, Gap-Analyse |
+
+**Optimale Kontingentnutzung:**
+
+- Claude uebernimmt die kontinuierlichen, kontextschweren Aufgaben (Analyse, Review, Architektur)
+- Codex uebernimmt die fokussierten, klar eingegrenzten Implementierungstasks
+- GitHub Actions ist der Event-basierte Kleber dazwischen
+
+## Voraussetzungen
+
+Was existiert und was fehlt:
+
+| Komponente | Status | Aufwand |
+|---|---|---|
+| Spec-Repository mit Test-Vektoren und Schemas | Existiert (`wot-spec/`) | — |
+| Conformance-Manifest | Existiert (`conformance/manifest.json`) | — |
+| CI Pipeline | Existiert (`.github/workflows/ci.yml`) | — |
+| ROADMAP.md mit Milestones | Existiert (`ROADMAP.md`) | — |
+| IMPLEMENTATION-ARCHITECTURE.md | Existiert (`IMPLEMENTATION-ARCHITECTURE.md`) | — |
+| Claude `/schedule` | Verfuegbar | Konfigurieren |
+| Codex CLI/API | Verfuegbar (ChatGPT Pro) | GitHub Action bauen |
+| Maschinenlesbarer Impl-Status pro Spec-Section | Fehlt | `conformance/impl-status.json` anlegen |
+| Cross-Review GitHub Action | Fehlt | Workflow schreiben |
+| Task-Template als Issue-Template | Fehlt | `.github/ISSUE_TEMPLATE/agent-task.md` |
+| Routing-Logik (Label-basiert) | Fehlt | Einfache Action oder Bot |
+
+## Implementierungsreihenfolge
+
+Jede Stufe ist einzeln nutzbar. Man muss nicht alles auf einmal bauen.
+
+### Stufe 1: Conformance-Waechter (1 Tag)
+
+- Claude `/schedule` Agent der taeglich `npm run validate` und `pnpm test` prueft
+- Issue nur bei Regression
+- **Sofortiger Nutzen:** Regressions-Fruehwarnung ohne manuelles Pruefen
+
+### Stufe 2: Gap-Analyse (1 Tag)
+
+- Claude `/schedule` Agent der woechentlich `manifest.json` gegen Implementierung abgleicht
+- Output als GitHub Issue
+- **Nutzen:** Anton muss nicht mehr selbst nachdenken was als naechstes dran ist
+
+### Stufe 3: Task-Template und Issue-Generierung (halber Tag)
+
+- GitHub Issue Template fuer `agent-task`
+- Claude generiert Tasks aus Gap-Analyse
+- Anton reviewed und labelt mit `ready`
+- **Nutzen:** Tasks sind fuer Agents konsumierbar, nicht nur fuer Menschen
+
+### Stufe 4: Cross-Review Action (1-2 Tage)
+
+- GitHub Action: bei PR mit Label `needs-cross-review`, trigger den jeweils anderen Agent
+- Claude reviewed via Claude Code / API
+- Codex reviewed via Codex API
+- Review als PR-Kommentar
+- **Nutzen:** Der groesste Qualitaets-Hebel — jeder PR wird von zwei unabhaengigen Agents geprueft
+
+### Stufe 5: Autonome Implementierung (2-3 Tage)
+
+- Agent pickt `ready`-Issues, erstellt Branch und PR
+- Claude via `/schedule` oder Webhook
+- Codex via GitHub Action oder API
+- **Nutzen:** Implementierung laeuft ohne dass Anton sie anstossen muss
+
+### Stufe 6: Vollstaendige Pipeline (laufend)
+
+- Alle Phasen verbunden
+- Feedback-Loop von Implementierung zurueck in Spec
+- Metriken: Durchsatz (PRs/Woche), Regressionsrate, Time-to-Merge
+- **Nutzen:** Spec-Push loest automatisch die gesamte Kette aus bis zum mergebaren PR
+
+## Risiken und Gegenmassnahmen
+
+| Risiko | Beschreibung | Gegenmassnahme |
+|---|---|---|
+| Drift | Agents implementieren etwas das der Spec nicht entspricht | Test-Vektoren als harte Gate-Bedingung, Cross-Review |
+| Schleifen | Agent A aendert, Agent B reverted, endlos | Max 2 Review-Zyklen, danach `needs-discussion` |
+| Spec-Luecken | Agent trifft Entscheidung die in der Spec nicht steht | `blocked`-Label, Rueckfrage an Mensch, kein stilles Raten |
+| Kontingent-Verschwendung | Agents arbeiten an niedrig-priorisierten Tasks | Prioritaeten in ROADMAP.md, nur `ready`-Issues werden bearbeitet |
+| Merge-Konflikte | Parallele Agents aendern dieselben Dateien | Scope in Task klar definieren, bei Konflikt: juengerer PR rebased |
+| Qualitaetserosion | "Zwei Agents approved" wird zum Rubber-Stamp | Conformance-Waechter als unabhaengige dritte Pruefung |
+
+## Metriken (nach Stufe 6)
+
+| Metrik | Ziel | Messung |
+|---|---|---|
+| Spec-Abdeckung | Jede MUST-Anforderung hat einen Test-Vektor | Gap-Analyse-Report |
+| Impl-Abdeckung | Jeder Test-Vektor hat einen gruenen Test | Conformance-Waechter |
+| Durchsatz | 5-10 gemergete PRs pro Woche | GitHub API |
+| Time-to-Merge | < 48h von Task-Erstellung bis Merge | GitHub API |
+| Regressionsrate | < 5% der PRs verursachen eine Regression | Conformance-Waechter |
+| Human-Aufwand | < 30 Minuten pro Tag fuer Merge-Entscheidungen | Selbstmessung |
+
+## Abgrenzung
+
+Dieses Konzept beschreibt die Automatisierung des **Implementierungs-Workflows**. Folgendes ist explizit nicht Teil der Pipeline:
+
+- **Spec-Authoring:** Normative Entscheidungen bleiben bei Menschen. Die Pipeline implementiert Spec, sie schreibt sie nicht.
+- **Architektur-Entscheidungen:** IMPLEMENTATION-ARCHITECTURE.md wird von Menschen geschrieben. Agents halten sich daran.
+- **Release-Management:** Tags, Changelogs und Veroeffentlichungen bleiben manuell oder werden separat automatisiert.
+- **Deployment:** Die bestehende Deploy-Pipeline (Docker, NixOS, Watchtower) ist orthogonal.
+- **Rust/HMC Track:** Die zweite Implementierung hat eigene Maintainer und einen eigenen Workflow. Die Pipeline liefert ihr Test-Vektoren und Conformance-Checks, nicht Code.
+
+## Zusammenfassung
+
+Die Pipeline verwandelt Spec-Aenderungen in gemergete PRs mit minimalem menschlichen Aufwand:
+
+```
+Spec aendern  -->  Gap erkannt  -->  Task generiert  -->  Agent implementiert
+     ^                                                           |
+     |                                                           v
+     +--- Spec-Luecke <--- Feedback <--- Human Gate <--- Cross-Review
+```
+
+Die Spezifikation ist die Kontrollschicht. Test-Vektoren sind die maschinenlesbare Autorisierung. Menschen entscheiden *was* gebaut wird (Spec) und *ob* es gut genug ist (Merge-Gate). Maschinen erledigen alles dazwischen.

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -233,7 +233,7 @@ Eine konforme Implementierung MUSS alle obigen SHA-256 Hashes reproduzieren. Wen
 
 ## Verwendung
 
-Eine konforme Implementierung MUSS:
+Eine konforme Implementierung MUSS fuer die jeweils beanspruchten Profile:
 
 1. Aus dem Mnemonic "abandon...about" dieselbe DID erzeugen.
 2. Den JWS-Testvektor verifizieren koennen (Signatur ueber den Signing Input mit dem Public Key).
@@ -241,7 +241,7 @@ Eine konforme Implementierung MUSS:
 4. Fuer alle JCS-Test-Vektoren dieselben SHA-256 Hashes erzeugen.
 5. Den Attestation-VC-JWS aus den Phase-1-Interop-Vektoren verifizieren koennen.
 6. Die Phase-1-Interop-Vektoren in [`phase-1-interop.md`](phase-1-interop.md) reproduzieren koennen.
-7. Die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
+7. Fuer `wot-device-delegation@0.1`: die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
 
 Wenn diese Tests bestehen, ist die kryptographische Basis interoperabel.
 


### PR DESCRIPTION
## Summary
- ergänzt Abschnitts-READMEs für Identity, Trust und Sync als Leseschicht über den normativen Detaildokumenten
- fügt einen Architektur-Kompass und ein nicht-normatives TypeScript-Implementation-Mapping hinzu
- präzisiert Device-Key-Delegation als geplantes Identity-Erweiterungsprofil und korrigiert kleine Trust-/Testvektor-Wording-Unschärfen

## Validation
- npm run validate