### PR TITLE
Clarify conformance ownership and recovery decisions

### DIFF
--- a/01-wot-identity/002-signaturen-und-verifikation.md
+++ b/01-wot-identity/002-signaturen-und-verifikation.md
@@ -177,15 +177,19 @@ function verifyJws(jws: string, did: string): boolean {
 }
 ```
 
-## Testvektor
+## Testvektoren und Profil-Zuordnung
 
-Vollständige, verifizierbare Test-Vektoren mit konkreten Krypto-Werten finden sich in den [Test-Vektoren](../test-vectors/). Diese enthalten:
+Vollständige, verifizierbare Test-Vektoren mit konkreten Krypto-Werten finden sich in den [Test-Vektoren](../test-vectors/). Fuer `wot-identity@0.1` sind die folgenden Vektorarten profileigen:
 
-1. **Identität:** Mnemonic → BIP39 Seed → HKDF → Ed25519 Key → did:key (mit exakten Hex-Werten für jeden Schritt)
-2. **JWS-Signatur:** Payload → JCS → Base64URL → Signing Input → Ed25519-Signatur → JWS Compact (mit verifizierbarer Signatur)
-3. **AES-256-GCM:** Plaintext → Verschlüsselung → Ciphertext + Auth Tag → Blob-Format
+1. **Identität:** Mnemonic → BIP39 Seed → HKDF → Ed25519 Key → did:key (mit exakten Hex-Werten fuer jeden Schritt).
+2. **DID-Resolution:** `did:key` → DID-Dokument und JCS-Fingerprint.
+3. **JCS-Kanonisierung:** Primitive JSON-Kanonisierungsfaelle einschliesslich Zahlenformatierung.
 
-Eine konforme Implementierung MUSS alle drei Test-Vektoren reproduzieren können.
+JCS und JWS sind normative Basistechniken von `wot-identity@0.1`. Konkrete JWS-Artefaktvektoren gehoeren aber zu dem Profil, das das jeweilige Artefakt definiert, z.B. Attestation-JWS zu `wot-trust@0.1`, Log-Entry-JWS und Space-Capability-JWS zu `wot-sync@0.1` und Device-Key-Binding-JWS zu `wot-device-delegation@0.1`.
+
+AES-256-GCM und ECIES sind keine `wot-identity@0.1`-Vektoren. Sie gehoeren zu den Sync-Verschluesselungsanforderungen in [Sync 001](../03-wot-sync/001-verschluesselung.md) und damit zu `wot-sync@0.1`.
+
+Eine `wot-identity@0.1`-konforme Implementierung MUSS die identity-, DID-resolution- und JCS-Vektoren reproduzieren oder verifizieren. Eine Implementierung MUSS zusaetzlich die Artefakt-JWS-Vektoren der Profile bestehen, die sie beansprucht.
 
 **Wichtig:** Ed25519 signiert direkt die Bytes des Signing Input — kein SHA-256 Hash dazwischen. Ed25519 hasht intern mit SHA-512. SHA-256 wird nur für andere Zwecke im Protokoll verwendet (z.B. Content-Adressierung), nicht für die JWS-Signatur selbst.
 

--- a/02-wot-trust/001-attestations.md
+++ b/02-wot-trust/001-attestations.md
@@ -139,6 +139,10 @@ Die Attestation gehört dem Subject. Konkret:
 
 Der Holder hat ein lokales `public`-Flag pro Attestation. Nicht veröffentlichte Attestations bleiben in der Wallet bzw. im Personal Doc und sind unsichtbar für Dritte (nicht im Profil-Service). Das Flag ist **nicht Teil des VC** und wird **nicht signiert** — es ist eine reine lokale Entscheidung, gespeichert als Metadaten neben dem JWS im Personal Doc.
 
+`wot-trust@0.1` definiert kein `attestation-ack` und keine semantische Annahmebestaetigung. Attestations sind Geschenke: Nach der Zustellung gehoeren sie dem Holder, und der Holder entscheidet privat, ob er sie speichert, ignoriert, anzeigt oder veroeffentlicht. Der Issuer erhaelt aus dem Trust-Protokoll keine Rueckmeldung darueber, ob der Holder die Attestation angenommen, gelesen, behalten oder intern vertraut hat.
+
+Transport-ACKs aus dem Sync-Layer bestaetigen nur die Verarbeitung oder durable Pufferung einer Inbox-Nachricht fuer ein bestimmtes Device. Sie DUERFEN nicht als Akzeptanz- oder Vertrauenssignal fuer eine Attestation interpretiert werden. Die einzige bewusste oeffentliche Rueckmeldung ist die spaetere Veroeffentlichung durch den Holder im Profil-Service (`/p/{did}/a`), falls der Holder das will.
+
 ## Unveränderlichkeit
 
 Attestations sind **unveränderlich.** Einmal signiert, kann der Inhalt nicht geändert werden ohne die JWS-Signatur zu brechen.

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -516,6 +516,8 @@ Der Empfänger schickt `ack` nach erfolgreichem Verarbeiten einer Inbox-Nachrich
 
 Der Broker kann die Nachricht dann aus der Inbox **dieses authentifizierten Devices** entfernen. Er DARF sie nicht aus anderen Device-Inboxen derselben DID entfernen. Wenn der Client eine Nachricht wegen fehlender Abhaengigkeiten nur volatil im Speicher haelt, DARF er sie noch nicht ACKen.
 
+Ein `ack/1.0` ist ausschliesslich eine Transport-/Persistenzbestaetigung fuer genau dieses Device. Es bestaetigt nicht, dass ein Inhaltsartefakt semantisch angenommen, vertraut, gelesen, angezeigt oder veroeffentlicht wurde. Insbesondere definiert `wot-trust@0.1` kein `attestation-ack`; ob ein Empfaenger eine Attestation spaeter oeffentlich zeigt, ergibt sich nur aus seiner bewussten Profil-Veroeffentlichung.
+
 #### Fehler-Responses
 
 Wenn eine Sync-Anfrage nicht erfüllt werden kann, antwortet der Broker mit einer Error-Nachricht:

--- a/03-wot-sync/004-discovery.md
+++ b/03-wot-sync/004-discovery.md
@@ -203,3 +203,18 @@ Fehler-Bodies sollten `Content-Type: text/plain` sein mit einer lesbaren Fehlerm
 ## Daten-Discovery
 
 Ein neues Gerät findet Personal Doc und Space-Dokumente über bekannte Broker oder über Multi-Device-Sync mit einem bestehenden Gerät. Der Broker liefert Dokument-IDs für die authentifizierte DID; die konkreten Sync-Formate sind in [Sync 002](002-sync-protokoll.md) und [Sync 003](003-transport-und-broker.md) spezifiziert.
+
+## Profil-Service-Recovery-Fallback
+
+Implementierungen DUERFEN den Profil-Service als Recovery-Fallback verwenden, wenn Vault, Personal Doc oder lokaler CRDT-State nicht erreichbar oder nicht lesbar sind. Dieser Fallback ist auf oeffentliche, signierte Profil-Service-Ressourcen begrenzt.
+
+Ein Profil-Service-Recovery-Fallback DARF rekonstruieren:
+
+- DID-Dokument und oeffentliche Profil-Daten aus `/p/{did}`.
+- veroeffentlichte Verifikationen aus `/p/{did}/v`.
+- bewusst veroeffentlichte Attestations aus `/p/{did}/a`.
+- oeffentliche `keyAgreement`- und `service`-Informationen aus dem DID-Dokument.
+
+Ein Profil-Service-Recovery-Fallback DARF NICHT als Recovery-Quelle fuer private Wallet-Zustaende, unveroeffentlichte empfangene Attestations, private Kontakte, Space Content Keys, Space-Mitgliedschaftsgeheimnisse, Personal-Doc-only State oder Vault Secrets verwendet werden.
+
+Clients MUESSEN bei diesem Fallback dieselben Pruefungen anwenden wie bei normalem Profil-Service-Abruf: JWS-Signatur, DID/Pfad-Konsistenz und Versionsmonotonie. Recovered Profile Data bleibt oeffentliches Profil-/Discovery-Datum und ist kein kanonischer Ersatz fuer Personal Doc oder Vault.

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -164,6 +164,16 @@ Empfaenger MUESSEN `member-update` gegen den naechsten Space-Sync verifizieren. 
 
 `member-update` ist zugleich ein Zustellsignal und ein lokales Pending-Signal. Es ist keine Autoritaet fuer den kanonischen Membership-State. Ein Client MUSS die Nachricht nach erfolgreicher Entschluesselung, JWS-Pruefung, Replay-Pruefung und durabel gespeichertem Pending-Signal ACKen; die ACK bestaetigt nur die lokale Annahme des Signals, nicht die kanonische Membership-Aenderung.
 
+#### Authority-Split (MUSS)
+
+Implementierungen MUESSEN `member-update` entlang dieser Verantwortlichkeitsgrenzen verarbeiten:
+
+- **Protocol:** prueft die normalisierte Nachrichtenform und kryptographischen Artefakte und klassifiziert deterministisch `(member-update, signerDid, localPolicySnapshot, existingPendingState)`. Die Protocol-Schicht kennt keinen Storage, Broker, CRDT, Adapter, UI oder Netzwerkzustand.
+- **Application:** stellt den lokalen Policy-Snapshot bereit, speichert Pending-Zustaende durabel, entscheidet lokale UX-/Write-Lock-Wirkung aus der Protocol-Klassifikation, loest Space-Catch-Up aus, loest Pending-Zustaende gegen die kanonische Mitgliederliste auf und sendet ACKs erst nach Anwendung oder durablem Puffern.
+- **Adapter:** transportiert, entschluesselt, liefert, persistiert technisch und uebertraegt per-Device ACKs. Adapter DUERFEN keine Mitgliedschaftsautoritaet, Signer-Policy-Autoritaet oder kanonische Membership-Entscheidung besitzen.
+
+Der lokale Policy-Snapshot enthaelt mindestens lokal bekannte Admin-DIDs, lokal bekannte Member-DIDs, die lokale Space-Key-Generation und bereits gespeicherte Pending-Tuples. Envelope-Komfortformen sind implementierungslokal; sie MUESSEN vor Protocol-/Application-Verarbeitung in die normativen Payload-Felder und Signer-Information normalisiert werden.
+
 Ein Client MUSS `member-update` anhand von `(spaceId, action, memberDid, effectiveKeyGeneration)` als Pending-Record zusammenfuehren. Exakte Duplikate mit gleichem Signer und gleicher Signer-Autorisierung MUESSEN ohne zusaetzliche UI-, Sync- oder State-Transitions ignoriert werden, nachdem die erste Nachricht durabel verarbeitet wurde. Eine spaeter empfangene Nachricht mit demselben Tuple, aber hoeherer lokaler Autorisierung, MUSS das Pending-Record upgraden (z.B. von `unverified-pending` zu actionable pending). Eine spaeter empfangene Nachricht mit niedrigerer oder unbekannter Autorisierung DARF ein bereits actionable Pending-Record nicht downgraden.
 
 Ein Client MUSS den Signer des inneren JWS gegen die lokal bekannte Space-Policy pruefen, bevor ein `member-update` vor der kanonischen Space-Sync-Bestaetigung UI- oder Schreibwirkung entfalten darf:
@@ -265,6 +275,8 @@ Inbox-Nachrichtentyp `key-rotation`, verschlüsselt mit ECIES:
 ```
 
 Der Admin sendet eine `key-rotation` Nachricht an **jedes** verbleibende Mitglied einzeln.
+
+`key-rotation` ist der einzige normative bekannte Inbox-Nachrichtentyp fuer Space-Key-Rotation in `wot-sync@0.1`. `group-key-rotation` ist kein normativer Nachrichtentyp und DARF von konformen Implementierungen nicht als bekannte Protocol-Type-URI beansprucht werden. Lokale Migrations-Aliase MUESSEN vor Protocol-Verarbeitung auf die normative `key-rotation`-Form normalisiert werden.
 
 Alte Daten bleiben mit alten Space Content Keys lesbar. Rotation schuetzt nur zukuenftige Daten und zukuenftigen Broker-Zugriff.
 

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -36,6 +36,7 @@ Eine Implementierung ist `wot-identity@0.1`-konform, wenn sie die folgenden Faeh
 
 - JWS Compact Serialization mit `alg=EdDSA` erzeugen und verifizieren.
 - JCS nach RFC 8785 fuer JSON-Payloads verwenden.
+- JCS-Primitive-Vektoren einschliesslich Zahlenformatierung reproduzieren oder verifizieren.
 - `kid` im JWS-Header verpflichtend setzen und auswerten.
 - Signatur-Keys ueber `resolve(did)` und DID-Dokumente aufloesen.
 
@@ -55,6 +56,7 @@ Eine Implementierung ist `wot-trust@0.1`-konform, wenn sie zusaetzlich `wot-iden
 - VC-JOSE-COSE JWS (`typ: "vc+jwt"`) fuer Attestations verifizieren.
 - `issuer`, `iss`, `credentialSubject.id`, `sub`, `validFrom` und `nbf` konsistent pruefen.
 - Nicht verstandene Extension-Felder ignorieren.
+- Keine semantische Annahmebestaetigung fuer Attestations verlangen oder aus Transport-ACKs ableiten. `wot-trust@0.1` definiert kein `attestation-ack`; Attestations sind nach gueltiger Signatur Wallet-Artefakte des Empfaengers. Eine spaetere Veroeffentlichung im Profil ist die bewusste oeffentliche Rueckmeldung des Empfaengers.
 
 ### Verifikation
 
@@ -95,6 +97,14 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Inbox-Nachrichten pro Device zustellen und ACKs verarbeiten.
 - Selbstadressierte Inbox-Nachrichten an andere Devices derselben DID zustellen, ohne das sendende Device als erfolgreich zugestellten Empfaenger zu behandeln.
 - Inbox-ACKs nur pro authentifiziertem Device anwenden und erst nach Entschluesselung, Verifikation, Replay-Pruefung und dauerhafter Anwendung oder durablem Pending-Speicher senden.
+- Inbox-ACKs als Transport-/Persistenzbestaetigung behandeln und nicht als semantische Annahme, Vertrauenserklaerung oder Veroeffentlichungsabsicht fuer Attestations oder andere Inhaltsartefakte interpretieren.
+
+### Discovery und Recovery
+
+- Profil-Service-Ressourcen als oeffentliche, signierte Discovery-Daten behandeln.
+- Profil-Service-Recovery nur fuer DID-Dokument, oeffentliches Profil, veroeffentlichte Verifikationen, bewusst veroeffentlichte Attestations sowie oeffentliche `keyAgreement`- und `service`-Informationen verwenden.
+- Profil-Service-Recovery nicht als Ersatz fuer Vault, Personal Doc, private Wallet, unveroeffentlichte empfangene Attestations, private Kontakte, Space Content Keys, Space-Mitgliedschaftsgeheimnisse oder andere private Sync-Zustaende behandeln.
+- Beim Recovery-Fallback JWS-Signatur, DID/Pfad-Konsistenz und Versionsmonotonie pruefen.
 
 ### Personal Doc und Gruppen
 

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -14,7 +14,7 @@
       "test_vectors": [
         {
           "file": "test-vectors/phase-1-interop.json",
-          "sections": ["identity", "did_resolution"]
+          "sections": ["identity", "did_resolution", "jcs_canonicalization"]
         }
       ]
     },

--- a/scripts/validate_test_vectors.py
+++ b/scripts/validate_test_vectors.py
@@ -2,6 +2,8 @@
 import base64
 import hashlib
 import json
+import math
+import re
 from pathlib import Path
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -44,7 +46,46 @@ def b58decode(value: str) -> bytes:
 
 
 def jcs(value) -> bytes:
-    return json.dumps(value, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return jcs_string(value).encode("utf-8")
+
+
+def jcs_string(value) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return jcs_number(value)
+    if isinstance(value, list):
+        return "[" + ",".join(jcs_string(item) for item in value) + "]"
+    if isinstance(value, dict):
+        return "{" + ",".join(
+            f"{json.dumps(key, ensure_ascii=False, separators=(',', ':'))}:{jcs_string(value[key])}"
+            for key in sorted(value)
+        ) + "}"
+    raise TypeError(f"unsupported JCS value: {type(value).__name__}")
+
+
+def jcs_number(value: float) -> str:
+    if not math.isfinite(value):
+        raise ValueError("non-finite numbers are not valid JSON numbers")
+    if value == 0:
+        return "0"
+    if value.is_integer() and abs(value) < 1e21:
+        return str(int(value))
+    encoded = json.dumps(value, ensure_ascii=False, allow_nan=False, separators=(",", ":"))
+    return re.sub(r"e([+-])0+(\d)", r"e\1\2", encoded)
+
+
+def load_json_strict(value: str):
+    def reject_constant(constant: str):
+        raise ValueError(f"invalid JSON number: {constant}")
+
+    return json.loads(value, parse_constant=reject_constant)
 
 
 def hkdf(ikm: bytes, info: str, length: int = 32) -> bytes:
@@ -161,6 +202,18 @@ def main() -> None:
     assert did_doc["did_document"]["keyAgreement"][0]["publicKeyMultibase"] == multibase_x(x_pub)
     assert hashlib.sha256(jcs(did_doc["did_document"])).hexdigest() == did_doc["jcs_sha256"]
     print("did resolution ok")
+
+    for case in data["jcs_canonicalization"]["valid_cases"]:
+        canonical = jcs_string(case["input"])
+        assert canonical == case["canonical"], case["name"]
+        assert hashlib.sha256(canonical.encode("utf-8")).hexdigest() == case["sha256"], case["name"]
+    for case in data["jcs_canonicalization"]["invalid_cases"]:
+        try:
+            load_json_strict(case["json"])
+        except ValueError:
+            continue
+        raise AssertionError(f"invalid JCS case accepted: {case['name']}")
+    print("jcs canonicalization ok")
 
     attestation = data["attestation_vc_jws"]
     header_b64, payload_b64, sig_b64 = attestation["jws"].split(".")

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -63,6 +63,57 @@
     },
     "jcs_sha256": "9f71bde97db9df9bc5fd14ab3c5a65dd3eb3e77fd1e74a43fe187a718015fefc"
   },
+  "jcs_canonicalization": {
+    "valid_cases": [
+      {
+        "name": "lexicographic_keys",
+        "input": { "z": 0, "a": 1 },
+        "canonical": "{\"a\":1,\"z\":0}",
+        "sha256": "b55af27c4bd5f02ebeca8f901b84d2940b22e7bea7230e4d06f275d903bfdd72"
+      },
+      {
+        "name": "minus_zero",
+        "input": { "n": -0 },
+        "canonical": "{\"n\":0}",
+        "sha256": "f3013f933b9fb80ab6d995e7ad9da36f683837ba1d81e950c943d40111eac2f0"
+      },
+      {
+        "name": "large_exponent",
+        "input": { "n": 1e30 },
+        "canonical": "{\"n\":1e+30}",
+        "sha256": "53bcca850cd9028c384aef303539ce41d82d7fb56fbfa1e5289fe51caef28f93"
+      },
+      {
+        "name": "small_exponent",
+        "input": { "n": 1e-7 },
+        "canonical": "{\"n\":1e-7}",
+        "sha256": "747d6d23b64d1b2d579adb832b44de31c91c875bbef7a8e397f5d183a746b54b"
+      },
+      {
+        "name": "shortest_roundtrip_decimal",
+        "input": { "n": 333333333.3333333 },
+        "canonical": "{\"n\":333333333.3333333}",
+        "sha256": "8e1aa496328ac7acbd045b34464ae11d72d8b525c355b85099382ffcb499143b"
+      }
+    ],
+    "invalid_cases": [
+      {
+        "name": "nan",
+        "json": "{\"n\":NaN}",
+        "expectedError": "invalid-json-number"
+      },
+      {
+        "name": "infinity",
+        "json": "{\"n\":Infinity}",
+        "expectedError": "invalid-json-number"
+      },
+      {
+        "name": "negative_infinity",
+        "json": "{\"n\":-Infinity}",
+        "expectedError": "invalid-json-number"
+      }
+    ]
+  },
   "attestation_vc_jws": {
     "header": {
       "alg": "EdDSA",

--- a/test-vectors/phase-1-interop.md
+++ b/test-vectors/phase-1-interop.md
@@ -47,6 +47,20 @@ Ein Bootstrap-DID-Dokument nach QR- oder Profil-Service-Kontakt:
 SHA-256(JCS DID Document): 9f71bde97db9df9bc5fd14ab3c5a65dd3eb3e77fd1e74a43fe187a718015fefc
 ```
 
+## 2a. JCS-Kanonisierung (Identity 002)
+
+Diese Vektoren pruefen primitive JCS-Faelle, die nicht zu einem konkreten Artefakt-Payload gehoeren:
+
+| Name | Canonical JSON | SHA-256 |
+|---|---|---|
+| `lexicographic_keys` | `{"a":1,"z":0}` | `b55af27c4bd5f02ebeca8f901b84d2940b22e7bea7230e4d06f275d903bfdd72` |
+| `minus_zero` | `{"n":0}` | `f3013f933b9fb80ab6d995e7ad9da36f683837ba1d81e950c943d40111eac2f0` |
+| `large_exponent` | `{"n":1e+30}` | `53bcca850cd9028c384aef303539ce41d82d7fb56fbfa1e5289fe51caef28f93` |
+| `small_exponent` | `{"n":1e-7}` | `747d6d23b64d1b2d579adb832b44de31c91c875bbef7a8e397f5d183a746b54b` |
+| `shortest_roundtrip_decimal` | `{"n":333333333.3333333}` | `8e1aa496328ac7acbd045b34464ae11d72d8b525c355b85099382ffcb499143b` |
+
+`NaN`, `Infinity` und `-Infinity` sind keine gueltigen JSON-Zahlen und MUESSEN vor oder waehrend der JCS-Kanonisierung abgelehnt werden.
+
 ## 3. Attestation VC-JWS (Trust 001)
 
 Payload ist das gültige Beispiel aus `schemas/examples/valid/attestation-vc-payload.json`, kanonisiert mit JCS und als `vc+jwt` signiert.


### PR DESCRIPTION
## Summary

- Clarifies JWS/JCS/AES vector ownership across identity, trust, and sync profiles.
- Adds identity-owned JCS canonicalization vectors and validator coverage.
- Records the member-update authority split, public profile recovery boundary, normative `key-rotation` naming, and no-`attestation-ack` trust semantics.

## Classification

- Normative clarification: yes.
- Test-vector change: yes, adds `phase-1-interop.json#jcs_canonicalization`.
- Conformance manifest/profile change: yes, adds the JCS vector section to `wot-identity@0.1`.
- Schema change: no.
- Breaking change: no intended wire-format change; `group-key-rotation` is clarified as non-normative legacy/local alias.

## Validation

- `npm run validate`: pass
- `git diff --check`: pass

## Downstream Handoff

- `web-of-trust` PR #28 should add/refresh fixture coverage for `jcs_canonicalization` if it continues to own JCS test coverage.
- `web-of-trust` PR #27 is not blocked by these decisions; it should avoid describing downstream JWS/AES vectors as identity-owned.
- Handoff comments posted:
  - https://github.com/real-life-org/web-of-trust/pull/28#issuecomment-4386473697
  - https://github.com/real-life-org/web-of-trust/pull/27#issuecomment-4386473679

## Resolves

Closes #16.
Closes #17.
Closes #18.
Closes #19.
Closes #20.
Closes #21.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified attestation acceptance semantics and acknowledgment behavior across trust and sync layers
  * Added profile service recovery fallback procedures
  * Enhanced member update processing guidelines with role-based responsibilities
  * Updated conformance requirements

* **Test Vectors & Validation**
  * Added comprehensive JSON canonicalization test vectors with SHA-256 validation
  * Improved validation script with stricter JSON parsing and canonicalization testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->