### PR TITLE
Clarify sync conformance decisions

### DIFF
--- a/03-wot-sync/001-verschluesselung.md
+++ b/03-wot-sync/001-verschluesselung.md
@@ -72,7 +72,7 @@ Clients MÜSSEN den Encryption Key nach dem ersten Empfang lokal cachen. In JWE-
 
 Die Nonce wird dem Ciphertext vorangestellt. AES-256-GCM ist nativ in der Web Crypto API aller Browser verfügbar und Hardware-beschleunigt (AES-NI).
 
-Das Segment `Ciphertext + Authentication Tag` MUSS mindestens ein Ciphertext-Byte plus den 16-Byte Authentication Tag enthalten. WoT-Sync-Payloads und ECIES-Inbox-Nachrichten haben keine semantisch gueltige leere Nutzlast: Implementierungen MUESSEN leeren Klartext vor der Verschluesselung ablehnen und MUESSEN beim Entschluesseln tag-only Ciphertexts ablehnen.
+Das Segment `Ciphertext + Authentication Tag` MUSS mindestens ein Ciphertext-Byte plus den 16-Byte Authentication Tag enthalten. ECIES-Inbox-Nachrichten und Log-Payloads MÜSSEN nicht-leere Klartexte verwenden: Implementierungen MÜSSEN leeren Klartext vor der Verschlüsselung ablehnen und MÜSSEN beim Entschlüsseln tag-only Ciphertexts ablehnen.
 
 ### Nonce-Konstruktion
 
@@ -114,8 +114,8 @@ Für direkte Nachrichten zwischen zwei Parteien (Attestations, Einladungen, Key-
    - Salt: leer (32 Null-Bytes)
    - Info: `"wot/ecies/v1"`
    - Ausgabe: 256-Bit AES-Schlüssel
-4. Nicht-leeren Klartext mit AES-256-GCM verschlüsseln (zufällige 12-Byte Nonce)
-5. Ausgabe: `{ ciphertext, nonce, ephemeralPublicKey }`
+4. Der nicht-leere Klartext MUSS mit AES-256-GCM verschlüsselt werden; dafür MUSS eine zufällige 12-Byte-Nonce verwendet werden.
+5. Die Ausgabe MUSS `{ ciphertext, nonce, ephemeralPublicKey }` enthalten.
 
 ### Entschlüsselung (Empfänger)
 

--- a/03-wot-sync/001-verschluesselung.md
+++ b/03-wot-sync/001-verschluesselung.md
@@ -72,6 +72,8 @@ Clients MÜSSEN den Encryption Key nach dem ersten Empfang lokal cachen. In JWE-
 
 Die Nonce wird dem Ciphertext vorangestellt. AES-256-GCM ist nativ in der Web Crypto API aller Browser verfügbar und Hardware-beschleunigt (AES-NI).
 
+Das Segment `Ciphertext + Authentication Tag` MUSS mindestens ein Ciphertext-Byte plus den 16-Byte Authentication Tag enthalten. WoT-Sync-Payloads und ECIES-Inbox-Nachrichten haben keine semantisch gueltige leere Nutzlast: Implementierungen MUESSEN leeren Klartext vor der Verschluesselung ablehnen und MUESSEN beim Entschluesseln tag-only Ciphertexts ablehnen.
+
 ### Nonce-Konstruktion
 
 AES-256-GCM ist **katastrophal unsicher** wenn dieselbe (Key, Nonce)-Kombination zweimal verwendet wird (Authentication-Key-Recovery, Klartext-Recovery). Die Spec definiert zwei verschiedene Nonce-Konstruktionen je nach Kontext:
@@ -106,18 +108,20 @@ Für direkte Nachrichten zwischen zwei Parteien (Attestations, Einladungen, Key-
 
 1. Ephemeres X25519-Schlüsselpaar generieren
 2. ECDH: `shared_secret = ephemeral_private × recipient_public`
+   - Wenn `shared_secret` der all-zero 32-Byte-Wert ist, MUSS die Nachricht abgelehnt werden. Der Wert DARF NICHT in HKDF eingehen.
 3. HKDF-SHA256:
    - Input: `shared_secret`
    - Salt: leer (32 Null-Bytes)
    - Info: `"wot/ecies/v1"`
    - Ausgabe: 256-Bit AES-Schlüssel
-4. Klartext mit AES-256-GCM verschlüsseln (zufällige 12-Byte Nonce)
+4. Nicht-leeren Klartext mit AES-256-GCM verschlüsseln (zufällige 12-Byte Nonce)
 5. Ausgabe: `{ ciphertext, nonce, ephemeralPublicKey }`
 
 ### Entschlüsselung (Empfänger)
 
 1. Ephemeral Public Key aus der Nachricht lesen
 2. ECDH: `shared_secret = recipient_private × ephemeral_public`
+   - Wenn `shared_secret` der all-zero 32-Byte-Wert ist, MUSS die Nachricht abgelehnt werden. Der Wert DARF NICHT in HKDF eingehen.
 3. Denselben AES-Schlüssel via HKDF ableiten
 4. Ciphertext entschlüsseln
 
@@ -151,7 +155,7 @@ ECIES verwendet einen ephemeren Sender-Key und den statischen X25519-Key des Emp
 |------|-----|-------------|
 | `epk` | String | Ephemerer X25519 Public Key (Base64URL, 32 Bytes) |
 | `nonce` | String | AES-256-GCM Nonce (Base64URL, 12 Bytes) |
-| `ciphertext` | String | Verschlüsselter Inhalt + AES-GCM Auth Tag (Base64URL) |
+| `ciphertext` | String | Verschlüsselter nicht-leerer Inhalt + AES-GCM Auth Tag (Base64URL; dekodiert mindestens 17 Bytes) |
 
 ### DIDComm-Abgrenzung
 

--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -42,7 +42,9 @@ Jedes Gerät generiert beim ersten Start eine zufällige **Device-UUID** und spe
 deviceId = crypto.randomUUID()
 ```
 
-Log-Einträge werden pro `deviceId` pro `docId` sequenziert. Die UUID ist kein kryptografischer Key, sondern nur der Sequenz- und Nonce-Namespace eines Devices.
+Neue Devices MUESSEN ihre `deviceId` als kanonische lowercase UUID v4 erzeugen. Log-Einträge werden pro `deviceId` pro `docId` sequenziert. Die UUID ist kein kryptografischer Key, sondern nur der Sequenz- und Nonce-Namespace eines Devices.
+
+Alle `deviceId`- und `docId`-Werte im Sync-Log MUESSEN als kanonische lowercase UUID v4 serialisiert werden. Deterministische Document-IDs, z.B. die Personal-Doc-ID aus [Sync 006](006-personal-doc.md#deterministische-document-id), MUESSEN beim Formatieren die UUID-v4-Version- und Variant-Bits setzen.
 
 ## Log
 
@@ -70,10 +72,10 @@ Ein Log-Eintrag ist ein **persistentes WoT-Objekt**: ein JWS-signierter Datensat
 |------|-----|---------|-------------|
 | `seq` | Integer | Ja | Aufsteigend, pro deviceId pro docId. Beginnt bei 0. |
 | `deviceId` | UUID v4 | Ja | Welches Gerät hat den Eintrag erzeugt |
-| `docId` | UUID v4 | Ja | Zu welchem Dokument gehört der Eintrag |
+| `docId` | UUID v4 | Ja | Zu welchem Dokument gehört der Eintrag. Deterministische IDs setzen die UUID-v4-Version- und Variant-Bits beim Formatieren. |
 | `authorKid` | DID-URL | Ja | Verification Method ID des Signierenden (z.B. `did:key:z6Mk...#sig-0`). DID wird aus dem Teil vor `#` extrahiert. In Phase 1 ist das Fragment immer `#sig-0` (einziger Key). In Phase 2 identifiziert es einen spezifischen Device-Key. |
 | `keyGeneration` | Integer | Ja | Generation des Space Content Keys der zur Verschlüsselung verwendet wurde (siehe [Sync 001](001-verschluesselung.md)) |
-| `data` | String | Ja | Base64URL-kodierter AES-256-GCM Ciphertext (Nonce + Ciphertext + Auth Tag, siehe [Sync 001](001-verschluesselung.md)) |
+| `data` | String | Ja | Base64URL-kodierter AES-256-GCM Ciphertext (Nonce + nicht-leerer Ciphertext + Auth Tag, siehe [Sync 001](001-verschluesselung.md)) |
 | `timestamp` | ISO 8601 | Ja | Erstellungszeitpunkt (UTC) |
 
 ### seq-Konsistenz (MUSS)
@@ -128,12 +130,14 @@ Der DIDComm-Envelope ist **kein Autoritätsanker** für den Log-Eintrag. Empfän
 Der `data`-Blob enthält ein mit AES-256-GCM verschlüsseltes CRDT-Update:
 
 ```
-Klartext (CRDT-Update, z.B. Yjs-Binary)
+Nicht-leerer Klartext (CRDT-Update, z.B. Yjs-Binary)
   → AES-256-GCM verschlüsseln mit Space Content Key (Generation = keyGeneration)
   → Nonce (12 Bytes) + Ciphertext + Auth Tag (16 Bytes)
   → Base64URL kodieren
   → in `data`-Feld schreiben
 ```
+
+Ein Log-Payload mit leerem Klartext ist in `wot-sync@0.1` ungueltig. Empfaenger MUESSEN dekodierte `data`-Blobs ablehnen, die nur aus Nonce und Authentication Tag bestehen und keine Ciphertext-Bytes enthalten.
 
 ### CRDT-Agnostik
 
@@ -151,7 +155,7 @@ Wenn eine Implementierung einen Snapshot oder Full-State-Payload uebertraegt, ge
 - Ein Empfaenger DARF einen Snapshot nur mergen, wenn er zur erwarteten `docId` und `keyGeneration` passt.
 - Peers MUESSEN weiterhin Log-Eintraege mit `authorKid`, `seq`, `deviceId` und `keyGeneration` verifizieren koennen.
 
-Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format. Ein Snapshot ist nicht autoritativ gegenueber bereits bekannten gueltigen CRDT-Operationen: Clients MUESSEN einen Snapshot ueber den jeweiligen CRDT mergen und DUERFEN ihn nicht verwenden, um lokal bekannte gueltige Log-Eintraege zurueckzurollen oder zu ersetzen. Wenn der CRDT-Import oder Merge eines Snapshots fehlschlaegt, MUSS der Client den Snapshot ignorieren und mit Log-/State-Sync fortfahren.
+Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format. `wot-sync@0.1` standardisiert keinen Snapshot- oder Full-State-Message-Type und kein Snapshot-Body-Schema. Ein Snapshot ist nicht autoritativ gegenueber bereits bekannten gueltigen CRDT-Operationen: Clients MUESSEN einen Snapshot ueber den jeweiligen CRDT mergen und DUERFEN ihn nicht verwenden, um lokal bekannte gueltige Log-Eintraege zurueckzurollen oder zu ersetzen. Wenn der CRDT-Import oder Merge eines Snapshots fehlschlaegt, MUSS der Client den Snapshot ignorieren und mit Log-/State-Sync fortfahren.
 
 ## Sync-Modi
 
@@ -166,7 +170,7 @@ Die folgenden Flows definieren die Reihenfolge der Operationen fuer `wot-sync@0.
 - Dauerhafter Zustand MUSS aus Log-Eintraegen, Personal-Doc-Eintraegen, Space-Metadaten, Group Keys und durabel gepufferten Inbox-Nachrichten rekonstruierbar sein.
 - Durabel gepufferte Pending-Zustaende, z.B. Pending-Inbox, `blocked-by-key` oder `future-rotation`, sind lokaler crash-sicherer State. Der konkrete Speicherort ist implementationsspezifisch, MUSS aber App-Neustarts ueberleben und MUSS alle Metadaten enthalten, die fuer erneute Pruefung und Anwendung noetig sind, mindestens Message-/Log-Entry-ID, betroffene `docId`, Abhaengigkeitsart und erwartete `keyGeneration`.
 - Ein Client DARF eine Inbox-Nachricht erst ACKen, wenn er sie entweder erfolgreich angewendet hat oder sie inklusive aller Abhaengigkeits-Metadaten dauerhaft gepuffert hat. Nach einem ACK darf der Broker die Nachricht fuer genau dieses Device loeschen (siehe [Sync 003 ACK](003-transport-und-broker.md#ack10--empfangsbestätigung)).
-- Ein Client DARF einen empfangenen Log-Eintrag nicht verwerfen, nur weil ihm der passende `keyGeneration`-Key fehlt. Er MUSS den Eintrag speichern oder erneut abrufbar lassen und den Eintrag als `blocked-by-key` behandeln.
+- Ein Client DARF einen gueltigen empfangenen Log-Eintrag mit vorhandener `keyGeneration` nicht verwerfen, nur weil ihm das passende Key-Material fehlt. Er MUSS den Eintrag speichern oder erneut abrufbar lassen und den Eintrag als `blocked-by-key` behandeln. Ein Log-Eintrag ohne Pflichtfeld `keyGeneration` ist malformed und wird vor dieser Disposition abgelehnt.
 - Push- und Inbox-Nachrichten sind Wecksignale oder Key-/Control-Messages. Sie ersetzen keinen Log-Catch-Up fuer das betroffene Dokument.
 - Snapshots, Full-State-Nachrichten und Vault-Backups sind Optimierungen. Sie duerfen keinen bekannten gueltigen Log-Eintrag zurueckrollen und duerfen eine fehlende Log-Sync-Runde nicht ersetzen.
 
@@ -227,17 +231,17 @@ Key-Rotation ist eine Abhaengigkeit fuer alle spaeteren Space-Log-Eintraege. Cli
 - Empfaengt ein Client eine `key-rotation` mit `generation = localGeneration + 1`, MUSS er den neuen Content Key und die neue Capability durabel speichern, blockierte Log-Eintraege dieser Generation erneut verarbeiten und einen `sync-request` fuer das Space-Dokument ausloesen.
 - Empfaengt ein Client eine `key-rotation` mit `generation <= localGeneration`, MUSS er sie als doppelt oder veraltet behandeln. Er DARF sie ACKen, nachdem Replay- und Signaturpruefung abgeschlossen sind.
 - Empfaengt ein Client eine `key-rotation` mit `generation > localGeneration + 1`, MUSS er sie als `future-rotation` durabel puffern. Er DARF sie nicht anwenden, bevor die Luecke geschlossen ist. Er MUSS fehlende Rotationen, Personal-Doc-Keys oder einen aktuellen Full-State/Log-Catch-Up anfordern.
-- Empfaengt ein Client einen Log-Eintrag mit unbekannter `keyGeneration`, MUSS er den Eintrag als `blocked-by-key` speichern oder erneut abrufbar lassen und Key-/Personal-Doc-Catch-Up anfordern. Er DARF den Eintrag nicht als verarbeitet markieren.
+- Empfaengt ein Client einen ansonsten gueltigen Log-Eintrag mit vorhandener, aber lokal unbekannter `keyGeneration`, MUSS er den Eintrag als `blocked-by-key` speichern oder erneut abrufbar lassen und Key-/Personal-Doc-Catch-Up anfordern. Er DARF den Eintrag nicht als verarbeitet markieren. Fehlt das Pflichtfeld `keyGeneration`, ist der Log-Eintrag malformed und wird nicht als `blocked-by-key` klassifiziert.
 - Sobald eine fehlende Generation verfuegbar wird, MUSS der Client alle gepufferten `future-rotation`-Nachrichten und `blocked-by-key`-Log-Eintraege in aufsteigender Generation erneut pruefen.
 
 `Anfordern` von fehlenden Rotationen oder Keys bedeutet in `wot-sync@0.1`, dass ein Client die bestehenden Sync-Quellen erneut nutzt: eigene Device-Inbox drainen, Personal Doc per `sync-request` aufholen, fuer das betroffene Space-Dokument einen `sync-request` senden und, falls implementiert, einen autorisierten Snapshot oder Full-State abrufen. Ein separates generisches `key-request` Nachrichtenformat ist in `wot-sync@0.1` nicht normiert. Solange die fehlende Generation danach nicht verfuegbar ist, MUSS der Client die betroffenen `future-rotation`- und `blocked-by-key`-Eintraege durabel gepuffert lassen und bei App-Start, Reconnect oder neuem Wecksignal erneut aufloesen.
 
 ### Snapshot- und Full-State-Optimierungen
 
-Snapshots und Full-State-Nachrichten duerfen verwendet werden, um lange Catch-Up-Runden zu beschleunigen. Sie MUESSEN aber wie folgt eingeordnet werden:
+Snapshots und Full-State-Nachrichten duerfen verwendet werden, um lange Catch-Up-Runden zu beschleunigen. Da `wot-sync@0.1` kein gemeinsames Snapshot-Wire-Format normiert, sind Snapshot-Bodies implementationsspezifisch. Sie MUESSEN aber wie folgt eingeordnet werden:
 
-1. Ein Snapshot MUSS mindestens `docId`, `keyGeneration` und eine Abdeckung der enthaltenen Log-Heads (`heads` oder aequivalente Metadaten) besitzen, wenn er als Catch-Up-Optimierung verwendet wird.
-2. Kann eine Implementierung die Abdeckung nicht bestimmen, DARF sie den Snapshot nur als CRDT-Merge-Hilfe verwenden und MUSS danach trotzdem eine normale `sync-request`-Runde ausfuehren.
+1. Ein Snapshot MUSS mindestens `docId`, `keyGeneration` und eine Abdeckung der enthaltenen Log-Heads besitzen, wenn er als Catch-Up-Optimierung verwendet wird. Die interoperable Abdeckungsform ist dieselbe `heads`-Map wie bei `sync-request`/`sync-response`: `deviceId -> hoechste enthaltene seq`.
+2. Kann eine Implementierung diese Abdeckung nicht bestimmen oder verwendet sie eine nicht interoperable Metadatenform, DARF sie den Snapshot nur als CRDT-Merge-Hilfe verwenden und MUSS danach trotzdem eine normale `sync-request`-Runde ausfuehren.
 3. Ein Snapshot mit unbekannter oder zukuenftiger `keyGeneration` wird wie ein blockierter Log-Eintrag behandelt: puffern oder erneut abrufen, fehlende Keys anfordern, nicht als verarbeitet markieren.
 4. Ein Snapshot DARF keine lokal bekannten gueltigen Log-Eintraege loeschen oder ueberschreiben. Der CRDT-Merge bleibt autoritativ fuer Konvergenz.
 5. Zeitbasierte Retry-Mechanismen duerfen als Implementierungsdetail existieren, sind aber nicht der normative Sync-Mechanismus. Normative Recovery basiert auf Heads, `sync-request`, per-Device-Inbox und Generation-Gap-Erkennung.

--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -42,9 +42,9 @@ Jedes Gerät generiert beim ersten Start eine zufällige **Device-UUID** und spe
 deviceId = crypto.randomUUID()
 ```
 
-Neue Devices MUESSEN ihre `deviceId` als kanonische lowercase UUID v4 erzeugen. Log-Einträge werden pro `deviceId` pro `docId` sequenziert. Die UUID ist kein kryptografischer Key, sondern nur der Sequenz- und Nonce-Namespace eines Devices.
+Neue Devices MÜSSEN ihre `deviceId` als kanonische lowercase UUID v4 erzeugen. Log-Einträge werden pro `deviceId` pro `docId` sequenziert. Die UUID ist kein kryptografischer Key, sondern nur der Sequenz- und Nonce-Namespace eines Devices.
 
-Alle `deviceId`- und `docId`-Werte im Sync-Log MUESSEN als kanonische lowercase UUID v4 serialisiert werden. Deterministische Document-IDs, z.B. die Personal-Doc-ID aus [Sync 006](006-personal-doc.md#deterministische-document-id), MUESSEN beim Formatieren die UUID-v4-Version- und Variant-Bits setzen.
+Alle `deviceId`- und `docId`-Werte im Sync-Log MÜSSEN als kanonische lowercase UUID v4 serialisiert werden. Deterministische Document-IDs, z.B. die Personal-Doc-ID aus [Sync 006](006-personal-doc.md#deterministische-document-id), MÜSSEN beim Formatieren die UUID-v4-Version- und Variant-Bits setzen.
 
 ## Log
 
@@ -137,7 +137,7 @@ Nicht-leerer Klartext (CRDT-Update, z.B. Yjs-Binary)
   → in `data`-Feld schreiben
 ```
 
-Ein Log-Payload mit leerem Klartext ist in `wot-sync@0.1` ungueltig. Empfaenger MUESSEN dekodierte `data`-Blobs ablehnen, die nur aus Nonce und Authentication Tag bestehen und keine Ciphertext-Bytes enthalten.
+Ein Log-Payload mit leerem Klartext ist in `wot-sync@0.1` ungültig. Empfänger MÜSSEN dekodierte `data`-Blobs ablehnen, die nur aus Nonce und Authentication Tag bestehen und keine Ciphertext-Bytes enthalten.
 
 ### CRDT-Agnostik
 
@@ -155,7 +155,7 @@ Wenn eine Implementierung einen Snapshot oder Full-State-Payload uebertraegt, ge
 - Ein Empfaenger DARF einen Snapshot nur mergen, wenn er zur erwarteten `docId` und `keyGeneration` passt.
 - Peers MUESSEN weiterhin Log-Eintraege mit `authorKid`, `seq`, `deviceId` und `keyGeneration` verifizieren koennen.
 
-Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format. `wot-sync@0.1` standardisiert keinen Snapshot- oder Full-State-Message-Type und kein Snapshot-Body-Schema. Ein Snapshot ist nicht autoritativ gegenueber bereits bekannten gueltigen CRDT-Operationen: Clients MUESSEN einen Snapshot ueber den jeweiligen CRDT mergen und DUERFEN ihn nicht verwenden, um lokal bekannte gueltige Log-Eintraege zurueckzurollen oder zu ersetzen. Wenn der CRDT-Import oder Merge eines Snapshots fehlschlaegt, MUSS der Client den Snapshot ignorieren und mit Log-/State-Sync fortfahren.
+Snapshots sind damit eine optionale Performance-Schicht, nicht das normative Sync-Wire-Format. `wot-sync@0.1` standardisiert keinen Snapshot- oder Full-State-Message-Type und kein Snapshot-Body-Schema. Ein Snapshot ist nicht autoritativ gegenüber bereits bekannten gültigen CRDT-Operationen: Clients MÜSSEN einen Snapshot über den jeweiligen CRDT mergen und DÜRFEN ihn nicht verwenden, um lokal bekannte gültige Log-Einträge zurückzurollen oder zu ersetzen. Wenn der CRDT-Import oder Merge eines Snapshots fehlschlägt, MUSS der Client den Snapshot ignorieren und mit Log-/State-Sync fortfahren.
 
 ## Sync-Modi
 
@@ -170,7 +170,7 @@ Die folgenden Flows definieren die Reihenfolge der Operationen fuer `wot-sync@0.
 - Dauerhafter Zustand MUSS aus Log-Eintraegen, Personal-Doc-Eintraegen, Space-Metadaten, Group Keys und durabel gepufferten Inbox-Nachrichten rekonstruierbar sein.
 - Durabel gepufferte Pending-Zustaende, z.B. Pending-Inbox, `blocked-by-key` oder `future-rotation`, sind lokaler crash-sicherer State. Der konkrete Speicherort ist implementationsspezifisch, MUSS aber App-Neustarts ueberleben und MUSS alle Metadaten enthalten, die fuer erneute Pruefung und Anwendung noetig sind, mindestens Message-/Log-Entry-ID, betroffene `docId`, Abhaengigkeitsart und erwartete `keyGeneration`.
 - Ein Client DARF eine Inbox-Nachricht erst ACKen, wenn er sie entweder erfolgreich angewendet hat oder sie inklusive aller Abhaengigkeits-Metadaten dauerhaft gepuffert hat. Nach einem ACK darf der Broker die Nachricht fuer genau dieses Device loeschen (siehe [Sync 003 ACK](003-transport-und-broker.md#ack10--empfangsbestätigung)).
-- Ein Client DARF einen gueltigen empfangenen Log-Eintrag mit vorhandener `keyGeneration` nicht verwerfen, nur weil ihm das passende Key-Material fehlt. Er MUSS den Eintrag speichern oder erneut abrufbar lassen und den Eintrag als `blocked-by-key` behandeln. Ein Log-Eintrag ohne Pflichtfeld `keyGeneration` ist malformed und wird vor dieser Disposition abgelehnt.
+- Ein Client DARF einen gültigen empfangenen Log-Eintrag mit vorhandener `keyGeneration` nicht verwerfen, nur weil ihm das passende Key-Material fehlt. Er MUSS den Eintrag speichern oder erneut abrufbar lassen und den Eintrag als `blocked-by-key` behandeln. Ein Log-Eintrag ohne Pflichtfeld `keyGeneration` ist malformed und wird vor dieser Disposition abgelehnt.
 - Push- und Inbox-Nachrichten sind Wecksignale oder Key-/Control-Messages. Sie ersetzen keinen Log-Catch-Up fuer das betroffene Dokument.
 - Snapshots, Full-State-Nachrichten und Vault-Backups sind Optimierungen. Sie duerfen keinen bekannten gueltigen Log-Eintrag zurueckrollen und duerfen eine fehlende Log-Sync-Runde nicht ersetzen.
 
@@ -231,19 +231,19 @@ Key-Rotation ist eine Abhaengigkeit fuer alle spaeteren Space-Log-Eintraege. Cli
 - Empfaengt ein Client eine `key-rotation` mit `generation = localGeneration + 1`, MUSS er den neuen Content Key und die neue Capability durabel speichern, blockierte Log-Eintraege dieser Generation erneut verarbeiten und einen `sync-request` fuer das Space-Dokument ausloesen.
 - Empfaengt ein Client eine `key-rotation` mit `generation <= localGeneration`, MUSS er sie als doppelt oder veraltet behandeln. Er DARF sie ACKen, nachdem Replay- und Signaturpruefung abgeschlossen sind.
 - Empfaengt ein Client eine `key-rotation` mit `generation > localGeneration + 1`, MUSS er sie als `future-rotation` durabel puffern. Er DARF sie nicht anwenden, bevor die Luecke geschlossen ist. Er MUSS fehlende Rotationen, Personal-Doc-Keys oder einen aktuellen Full-State/Log-Catch-Up anfordern.
-- Empfaengt ein Client einen ansonsten gueltigen Log-Eintrag mit vorhandener, aber lokal unbekannter `keyGeneration`, MUSS er den Eintrag als `blocked-by-key` speichern oder erneut abrufbar lassen und Key-/Personal-Doc-Catch-Up anfordern. Er DARF den Eintrag nicht als verarbeitet markieren. Fehlt das Pflichtfeld `keyGeneration`, ist der Log-Eintrag malformed und wird nicht als `blocked-by-key` klassifiziert.
+- Empfängt ein Client einen ansonsten gültigen Log-Eintrag mit vorhandener, aber lokal unbekannter `keyGeneration`, MUSS er den Eintrag als `blocked-by-key` speichern oder erneut abrufbar lassen und Key-/Personal-Doc-Catch-Up anfordern. Er DARF den Eintrag nicht als verarbeitet markieren. Fehlt das Pflichtfeld `keyGeneration`, ist der Log-Eintrag malformed und wird nicht als `blocked-by-key` klassifiziert.
 - Sobald eine fehlende Generation verfuegbar wird, MUSS der Client alle gepufferten `future-rotation`-Nachrichten und `blocked-by-key`-Log-Eintraege in aufsteigender Generation erneut pruefen.
 
 `Anfordern` von fehlenden Rotationen oder Keys bedeutet in `wot-sync@0.1`, dass ein Client die bestehenden Sync-Quellen erneut nutzt: eigene Device-Inbox drainen, Personal Doc per `sync-request` aufholen, fuer das betroffene Space-Dokument einen `sync-request` senden und, falls implementiert, einen autorisierten Snapshot oder Full-State abrufen. Ein separates generisches `key-request` Nachrichtenformat ist in `wot-sync@0.1` nicht normiert. Solange die fehlende Generation danach nicht verfuegbar ist, MUSS der Client die betroffenen `future-rotation`- und `blocked-by-key`-Eintraege durabel gepuffert lassen und bei App-Start, Reconnect oder neuem Wecksignal erneut aufloesen.
 
 ### Snapshot- und Full-State-Optimierungen
 
-Snapshots und Full-State-Nachrichten duerfen verwendet werden, um lange Catch-Up-Runden zu beschleunigen. Da `wot-sync@0.1` kein gemeinsames Snapshot-Wire-Format normiert, sind Snapshot-Bodies implementationsspezifisch. Sie MUESSEN aber wie folgt eingeordnet werden:
+Snapshots und Full-State-Nachrichten DÜRFEN verwendet werden, um lange Catch-Up-Runden zu beschleunigen. Da `wot-sync@0.1` kein gemeinsames Snapshot-Wire-Format normiert, sind Snapshot-Bodies implementationsspezifisch. Sie MÜSSEN aber wie folgt eingeordnet werden:
 
-1. Ein Snapshot MUSS mindestens `docId`, `keyGeneration` und eine Abdeckung der enthaltenen Log-Heads besitzen, wenn er als Catch-Up-Optimierung verwendet wird. Die interoperable Abdeckungsform ist dieselbe `heads`-Map wie bei `sync-request`/`sync-response`: `deviceId -> hoechste enthaltene seq`.
+1. Ein Snapshot MUSS mindestens `docId`, `keyGeneration` und eine Abdeckung der enthaltenen Log-Heads besitzen, wenn er als Catch-Up-Optimierung verwendet wird. Die interoperable Abdeckungsform ist dieselbe `heads`-Map wie bei `sync-request`/`sync-response`: kanonische lowercase UUID-v4-`deviceId` -> höchste enthaltene `seq`.
 2. Kann eine Implementierung diese Abdeckung nicht bestimmen oder verwendet sie eine nicht interoperable Metadatenform, DARF sie den Snapshot nur als CRDT-Merge-Hilfe verwenden und MUSS danach trotzdem eine normale `sync-request`-Runde ausfuehren.
 3. Ein Snapshot mit unbekannter oder zukuenftiger `keyGeneration` wird wie ein blockierter Log-Eintrag behandelt: puffern oder erneut abrufen, fehlende Keys anfordern, nicht als verarbeitet markieren.
-4. Ein Snapshot DARF keine lokal bekannten gueltigen Log-Eintraege loeschen oder ueberschreiben. Der CRDT-Merge bleibt autoritativ fuer Konvergenz.
+4. Ein Snapshot DARF keine lokal bekannten gültigen Log-Einträge löschen oder überschreiben. Der CRDT-Merge bleibt autoritativ für Konvergenz.
 5. Zeitbasierte Retry-Mechanismen duerfen als Implementierungsdetail existieren, sind aber nicht der normative Sync-Mechanismus. Normative Recovery basiert auf Heads, `sync-request`, per-Device-Inbox und Generation-Gap-Erkennung.
 
 ## Censorship- und Split-Brain-Detection

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -41,11 +41,11 @@ Beim Verbindungsaufbau zum Broker authentifiziert sich der Client via **Challeng
 2. Client sendet: { type: "register", did: "did:key:z6Mk...", deviceId: "uuid" }
 3. Broker generiert zufällige Nonce (32 Bytes)
 4. Broker sendet: { type: "challenge", nonce: "<Base64URL>" }
-5. Client signiert die Nonce mit Ed25519 Private Key
+5. Client signiert den Broker-Auth-Transcript mit Ed25519 Private Key
 6. Client sendet: { type: "challenge-response", did, deviceId, nonce, signature }
 7. Broker verifiziert:
    - DID auflösen → Public Key
-   - Signatur über Nonce prüfen
+   - Signatur über den Broker-Auth-Transcript prüfen
    - OK → Verbindung authentifiziert
 8. Broker sendet: { type: "registered", did, deviceId }
 ```
@@ -53,6 +53,8 @@ Beim Verbindungsaufbau zum Broker authentifiziert sich der Client via **Challeng
 Nach dem Handshake ist die WebSocket-Verbindung authentifiziert. Alle weiteren Nachrichten auf dieser Verbindung gelten als von dieser DID + deviceId kommend.
 
 Die Device-ID (`deviceId`) identifiziert das Gerät stabil — derselbe Wert wie im Sync-Protokoll ([Sync 002](002-sync-protokoll.md#device-identifikation)).
+
+`register.deviceId`, `challenge-response.deviceId`, `device-revoke.deviceId` und ACK-/Inbox-Scoping ueber `deviceId` MUESSEN die kanonische lowercase UUID-v4-Form verwenden. Broker MUESSEN malformed oder nicht-v4 Device-IDs vor einer Registrierung mit `MALFORMED_MESSAGE` ablehnen.
 
 ### Nonce-Handling (MUSS)
 
@@ -62,6 +64,24 @@ Die Challenge-Nonce in der Broker-Authentisierung MUSS denselben Replay-Schutz-R
 - Eine Nonce DARF nur einmal akzeptiert werden
 - Nonces MÜSSEN mindestens 32 Bytes aus einer kryptographisch sicheren Zufallsquelle haben
 - Clients MÜSSEN die Nonce direkt nach Empfang signieren (keine späteren Signaturen auf wiederverwendeten Nonces)
+
+### Broker-Auth-Transcript (MUSS)
+
+Die Signatur in `challenge-response` wird nicht ueber die rohen Nonce-Bytes und nicht ueber den Base64URL-String allein erzeugt. Sie MUSS ueber die JCS-kanonisierten Bytes des folgenden Transcripts erzeugt und verifiziert werden:
+
+```json
+{
+  "protocol": "wot/broker-auth/v1",
+  "type": "challenge-response",
+  "did": "did:key:z6Mk...",
+  "deviceId": "550e8400-e29b-41d4-a716-446655440000",
+  "nonce": "<kanonische unpadded Base64URL-Nonce>"
+}
+```
+
+Die `nonce` im Transcript ist die kanonische unpadded Base64URL-Darstellung der 32 zufaelligen Nonce-Bytes. Base64URL-Padding (`=`) ist in Broker-Challenges und Challenge-Responses ungueltig.
+
+Der Broker MUSS ausgegebene, noch nicht akzeptierte Nonces an die konkrete WebSocket-Verbindung und an die zuvor empfangenen `register.did` / `register.deviceId` Werte binden. `challenge-response.did`, `challenge-response.deviceId` und `challenge-response.nonce` MUESSEN exakt zu dieser ausstehenden Challenge passen, bevor die Signatur als gueltig akzeptiert wird. Nach erfolgreicher Akzeptanz MUSS die Nonce als verbraucht gespeichert werden; ein erneuter Versuch mit derselben Nonce wird mit `NONCE_REPLAY` abgelehnt.
 
 ## Device-Registrierung
 
@@ -76,7 +96,7 @@ Der Broker MUSS pro DID eine Liste der zugehörigen Device-IDs führen. Das ist 
 Wenn ein Client mit einer `(did, deviceId)`-Kombination verbindet, die der Broker noch nicht kennt:
 
 1. Broker führt normale Challenge-Response durch (siehe oben)
-2. Nach erfolgreicher Authentisierung: Broker prüft, ob `deviceId` bereits für eine **andere DID** registriert ist
+2. Nach erfolgreicher Authentisierung: Broker prüft, ob `deviceId` bereits für eine **andere DID** registriert ist, egal ob dort `active` oder `revoked`
    - Falls ja: **Ablehnen** mit `DEVICE_ID_CONFLICT` — Device-IDs MÜSSEN global eindeutig sein
 3. Broker prüft, ob `deviceId` für diese DID in einer Revocation-Liste steht
    - Falls ja: **Ablehnen** mit `DEVICE_REVOKED`
@@ -108,15 +128,24 @@ Device-Deaktivierung wird über eine **signierte Revocation-Nachricht** kommuniz
 Signiert mit dem Identity Key der angegebenen DID. Der Broker MUSS prüfen:
 
 1. JWS-Signatur gültig gegen den Ed25519-Key aus `did`
-2. Der Broker markiert `(did, deviceId)` als `revoked`
-3. Ausstehende Inbox-Nachrichten für dieses Device werden gelöscht
-4. Zukünftige Verbindungsversuche mit dieser Kombination werden mit `DEVICE_REVOKED` abgelehnt
+2. `deviceId` ist eine kanonische lowercase UUID v4 und `revokedAt` ist ein RFC3339-Date-Time mit expliziter Zeitzone
+3. Der Broker markiert `(did, deviceId)` als `revoked`
+4. Ausstehende Inbox-Nachrichten für dieses Device werden gelöscht
+5. Zukünftige Verbindungsversuche mit dieser Kombination werden mit `DEVICE_REVOKED` abgelehnt
+
+Jede gueltig mit dem Identity Key der DID signierte `device-revoke` Nachricht darf jedes Device derselben DID deaktivieren. Im Shared-Seed-Modell ist keine zusaetzliche Signatur eines device-spezifischen Keys erforderlich.
+
+Eine gueltige Revocation fuer ein unbekanntes `(did, deviceId)` MUSS der Broker als revoked Tombstone speichern und idempotent akzeptieren. Eine gueltige Revocation fuer ein bereits revoked Device MUSS ebenfalls idempotent akzeptiert werden; die zuerst gespeicherten Revocation-Metadaten bleiben autoritativ und werden durch spaetere Duplikate nicht ueberschrieben. Fuer Duplikate MUSS der Broker keine Inbox-Nachrichten erneut loeschen, DARF aber dieselbe Cleanup-Operation idempotent ausfuehren.
+
+Malformed `device-revoke` Nachrichten werden mit `MALFORMED_MESSAGE` abgelehnt. Ungueltige Signaturen, Signaturen eines anderen DID-Schluessels oder ein `did`/Signer-Mismatch werden mit `AUTH_INVALID` abgelehnt.
 
 **Limitation im Shared-Seed-Modell:** Wer den Seed hat, kann eine neue `deviceId` generieren und sich als "neues Device" registrieren. Device-Deaktivierung schützt nicht gegen Seed-Kompromittierung — siehe [Identity 001](../01-wot-identity/001-identitaet-und-schluesselableitung.md#multi-device--shared-seed-modell). Für echten Schutz muss die Identität rotiert werden.
 
 ### Device-Liste im Broker
 
 Der Broker speichert pro DID mindestens `deviceId`, `firstSeenAt`, `lastSeenAt`, `status` (`active` oder `revoked`) und optional `revokedAt`. Diese Liste ist Broker-Metadatum und liegt im Klartext vor.
+
+`active` und `revoked` sind die einzigen normativen Device-Statuswerte in `wot-sync@0.1`. Ein `revoked` Record ist ein Tombstone: solange der Broker ihn speichert, gilt die `deviceId` weiter als registriert und reserviert fuer Konfliktpruefungen. Eine fuer eine andere DID retained revoked `deviceId` fuehrt daher weiterhin zu `DEVICE_ID_CONFLICT`.
 
 ### Race Conditions
 
@@ -141,7 +170,7 @@ ACKs sind pro Device scoped. Ein Broker MUSS ein ACK nur fuer die Inbox des auth
 ### Retention und Garbage Collection
 
 - Nachrichten, die älter sind als ein definiertes TTL (z.B. 30 Tage) werden auch ohne ACK gelöscht — Implementierer dürfen das konfigurieren
-- Wenn ein Device für längere Zeit (z.B. 90 Tage) nicht verbindet, DARF der Broker es als inaktiv behandeln und seine ausstehenden Nachrichten löschen
+- Wenn ein Device für längere Zeit (z.B. 90 Tage) nicht verbindet, DARF der Broker es nach lokaler Retention-Policy als inaktiv behandeln und seine ausstehenden Nachrichten löschen. `inactive` ist kein normativer Statuswert; der Broker modelliert solche GCs lokal, ohne die `active`/`revoked`-Statusmenge zu erweitern.
 - Für kritische Nachrichten (Space-Einladungen, Key-Rotationen) SOLLTE der Sender einen Liefernachweis implementieren (z.B. erneutes Senden nach Timeout)
 
 Der pro-Device-Zustellpfad stellt sicher, dass jedes aktive Device kritische Nachrichten wie Space-Einladungen und Key-Rotationen mindestens einmal erhält.
@@ -302,6 +331,8 @@ Persistente WoT-Objekte (Attestation-JWS, Capability-JWS, Log-Entry-JWS, verschl
 | `thid` | UUID v4 | Optional | Thread-ID. Verknüpft Nachrichten die zu einer Konversation gehören (z.B. Request + Response). Die erste Nachricht eines Threads setzt `thid = id`; Folgenachrichten tragen denselben `thid`. |
 | `pthid` | UUID v4 | Optional | Parent-Thread-ID. Verweist auf einen übergeordneten Thread — für verschachtelte Konversationen (z.B. ein Sub-Protokoll das innerhalb eines größeren Flows läuft). |
 | `body` | Object | Ja | Nachrichteninhalt. Struktur abhängig vom `type`. |
+
+Das generische Plaintext-Envelope-Format DARF `to` weglassen, wenn der konkrete Nachrichtentyp seine Empfaenger aus dem authentifizierten Transportkontext oder aus dem Body ableitet, z.B. bei Broker-gebundenen `sync-request`/`sync-response` Nachrichten. Konkrete Nachrichtentypen DUERFEN strengere Regeln definieren. Inbox- und direkt adressierte Nachrichten MUESSEN `to` setzen.
 
 ### Autoritätsgrenze (MUSS)
 
@@ -545,6 +576,9 @@ Normative Error-Codes:
 | `DEVICE_REVOKED` | Device-ID ist als revoked markiert |
 | `DEVICE_ID_CONFLICT` | Device-ID bereits für eine andere DID registriert |
 | `SEQ_COLLISION_DETECTED` | Log-Eintrag mit `(docId, deviceId, seq)` existiert bereits mit anderem Content-Hash — Client MUSS neue `deviceId` generieren (Restore/Clone-Szenario) |
+| `MALFORMED_MESSAGE` | Nachricht oder Pflichtfeld ist syntaktisch ungueltig, inklusive malformed DID, malformed UUID v4 `deviceId`, malformed Base64URL-Nonce oder fehlender Pflichtfelder |
+| `AUTH_INVALID` | Challenge-Response, Envelope-JWS oder Device-Revocation-Signatur ist ungueltig oder passt nicht zu DID, Device oder ausstehender Challenge |
+| `NONCE_REPLAY` | Broker-Challenge-Nonce wurde bereits akzeptiert oder ist nicht mehr als ausstehende Challenge gueltig |
 | `RATE_LIMITED` | Rate-Limit überschritten |
 | `INTERNAL_ERROR` | Server-Fehler |
 
@@ -556,7 +590,7 @@ Neue Nachrichtentypen DÜRFEN von Extensions definiert werden. Ein Client der ei
 
 ### Envelope-Kompatibilität
 
-Das Plaintext-Envelope-Format ist **DIDComm-v2.1-kompatibel** auf Envelope-Ebene: `id`, `typ`, `type`, `from`, `to`, `created_time` (Unix-Seconds), `body`, `thid`/`pthid`. DIDComm-Bibliotheken können unsere Plaintext-Messages lesen und routen. Dieser Anspruch endet an der Envelope-Grenze: Verschlüsselung, Signaturen, persistente WoT-Objekte, Broker-Authentisierung und Sync-Semantik bleiben WoT-spezifisch.
+Das Plaintext-Envelope-Format ist **DIDComm-v2.1-kompatibel** auf Envelope-Ebene: `id`, `typ`, `type`, `from`, optional `to`, `created_time` (Unix-Seconds), `body`, `thid`/`pthid`. DIDComm-Bibliotheken können unsere Plaintext-Messages lesen und routen. Dieser Anspruch endet an der Envelope-Grenze: Verschlüsselung, Signaturen, persistente WoT-Objekte, Broker-Authentisierung und Sync-Semantik bleiben WoT-spezifisch.
 
 Für die Hintergründe dieser Entscheidung siehe [Research: Interop und Zielgruppe](../research/interop-und-zielgruppe.md).
 

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -54,7 +54,7 @@ Nach dem Handshake ist die WebSocket-Verbindung authentifiziert. Alle weiteren N
 
 Die Device-ID (`deviceId`) identifiziert das Gerät stabil — derselbe Wert wie im Sync-Protokoll ([Sync 002](002-sync-protokoll.md#device-identifikation)).
 
-`register.deviceId`, `challenge-response.deviceId`, `device-revoke.deviceId` und ACK-/Inbox-Scoping ueber `deviceId` MUESSEN die kanonische lowercase UUID-v4-Form verwenden. Broker MUESSEN malformed oder nicht-v4 Device-IDs vor einer Registrierung mit `MALFORMED_MESSAGE` ablehnen.
+`register.deviceId`, `challenge-response.deviceId`, `device-revoke.deviceId` und ACK-/Inbox-Scoping über `deviceId` MÜSSEN die kanonische lowercase UUID-v4-Form verwenden. Broker MÜSSEN malformed oder nicht-v4 Device-IDs vor einer Registrierung mit `MALFORMED_MESSAGE` ablehnen.
 
 ### Nonce-Handling (MUSS)
 
@@ -67,7 +67,7 @@ Die Challenge-Nonce in der Broker-Authentisierung MUSS denselben Replay-Schutz-R
 
 ### Broker-Auth-Transcript (MUSS)
 
-Die Signatur in `challenge-response` wird nicht ueber die rohen Nonce-Bytes und nicht ueber den Base64URL-String allein erzeugt. Sie MUSS ueber die JCS-kanonisierten Bytes des folgenden Transcripts erzeugt und verifiziert werden:
+Die Signatur in `challenge-response` wird nicht über die rohen Nonce-Bytes und nicht über den Base64URL-String allein erzeugt. Sie MUSS über die JCS-kanonisierten Bytes des folgenden Transcripts erzeugt und verifiziert werden:
 
 ```json
 {
@@ -79,9 +79,9 @@ Die Signatur in `challenge-response` wird nicht ueber die rohen Nonce-Bytes und 
 }
 ```
 
-Die `nonce` im Transcript ist die kanonische unpadded Base64URL-Darstellung der 32 zufaelligen Nonce-Bytes. Base64URL-Padding (`=`) ist in Broker-Challenges und Challenge-Responses ungueltig.
+Die `nonce` im Transcript ist die kanonische unpadded Base64URL-Darstellung der 32 zufälligen Nonce-Bytes. Base64URL-Padding (`=`) ist in Broker-Challenges und Challenge-Responses ungültig.
 
-Der Broker MUSS ausgegebene, noch nicht akzeptierte Nonces an die konkrete WebSocket-Verbindung und an die zuvor empfangenen `register.did` / `register.deviceId` Werte binden. `challenge-response.did`, `challenge-response.deviceId` und `challenge-response.nonce` MUESSEN exakt zu dieser ausstehenden Challenge passen, bevor die Signatur als gueltig akzeptiert wird. Nach erfolgreicher Akzeptanz MUSS die Nonce als verbraucht gespeichert werden; ein erneuter Versuch mit derselben Nonce wird mit `NONCE_REPLAY` abgelehnt.
+Der Broker MUSS ausgegebene, noch nicht akzeptierte Nonces an die konkrete WebSocket-Verbindung und an die zuvor empfangenen `register.did` / `register.deviceId` Werte binden. `challenge-response.did`, `challenge-response.deviceId` und `challenge-response.nonce` MÜSSEN exakt zu dieser ausstehenden Challenge passen, bevor die Signatur als gültig akzeptiert wird. Nach erfolgreicher Akzeptanz MUSS die Nonce als verbraucht gespeichert werden; ein erneuter Versuch mit derselben Nonce wird mit `NONCE_REPLAY` abgelehnt.
 
 ## Device-Registrierung
 
@@ -96,7 +96,7 @@ Der Broker MUSS pro DID eine Liste der zugehörigen Device-IDs führen. Das ist 
 Wenn ein Client mit einer `(did, deviceId)`-Kombination verbindet, die der Broker noch nicht kennt:
 
 1. Broker führt normale Challenge-Response durch (siehe oben)
-2. Nach erfolgreicher Authentisierung: Broker prüft, ob `deviceId` bereits für eine **andere DID** registriert ist, egal ob dort `active` oder `revoked`
+2. Nach erfolgreicher Authentisierung: Broker prüft, ob `deviceId` bereits für eine **andere DID** registriert ist, egal ob dort `active` oder `revoked` (siehe [Device-Liste](#device-liste))
    - Falls ja: **Ablehnen** mit `DEVICE_ID_CONFLICT` — Device-IDs MÜSSEN global eindeutig sein
 3. Broker prüft, ob `deviceId` für diese DID in einer Revocation-Liste steht
    - Falls ja: **Ablehnen** mit `DEVICE_REVOKED`
@@ -133,11 +133,11 @@ Signiert mit dem Identity Key der angegebenen DID. Der Broker MUSS prüfen:
 4. Ausstehende Inbox-Nachrichten für dieses Device werden gelöscht
 5. Zukünftige Verbindungsversuche mit dieser Kombination werden mit `DEVICE_REVOKED` abgelehnt
 
-Jede gueltig mit dem Identity Key der DID signierte `device-revoke` Nachricht darf jedes Device derselben DID deaktivieren. Im Shared-Seed-Modell ist keine zusaetzliche Signatur eines device-spezifischen Keys erforderlich.
+Jede gültig mit dem Identity Key der DID signierte `device-revoke` Nachricht DARF jedes Device derselben DID deaktivieren. Im Shared-Seed-Modell ist keine zusätzliche Signatur eines device-spezifischen Keys erforderlich.
 
-Eine gueltige Revocation fuer ein unbekanntes `(did, deviceId)` MUSS der Broker als revoked Tombstone speichern und idempotent akzeptieren. Eine gueltige Revocation fuer ein bereits revoked Device MUSS ebenfalls idempotent akzeptiert werden; die zuerst gespeicherten Revocation-Metadaten bleiben autoritativ und werden durch spaetere Duplikate nicht ueberschrieben. Fuer Duplikate MUSS der Broker keine Inbox-Nachrichten erneut loeschen, DARF aber dieselbe Cleanup-Operation idempotent ausfuehren.
+Eine gültige Revocation für ein unbekanntes `(did, deviceId)` MUSS der Broker als revoked Tombstone speichern und idempotent akzeptieren. Eine gültige Revocation für ein bereits revoked Device MUSS ebenfalls idempotent akzeptiert werden; die zuerst gespeicherten Revocation-Metadaten bleiben autoritativ und werden durch spätere Duplikate nicht überschrieben. Für Duplikate MUSS der Broker keine Inbox-Nachrichten erneut löschen, DARF aber dieselbe Cleanup-Operation idempotent ausführen.
 
-Malformed `device-revoke` Nachrichten werden mit `MALFORMED_MESSAGE` abgelehnt. Ungueltige Signaturen, Signaturen eines anderen DID-Schluessels oder ein `did`/Signer-Mismatch werden mit `AUTH_INVALID` abgelehnt.
+Malformed `device-revoke` Nachrichten werden mit `MALFORMED_MESSAGE` abgelehnt. Ungültige Signaturen, Signaturen eines anderen DID-Schlüssels oder ein `did`/Signer-Mismatch werden mit `AUTH_INVALID` abgelehnt.
 
 **Limitation im Shared-Seed-Modell:** Wer den Seed hat, kann eine neue `deviceId` generieren und sich als "neues Device" registrieren. Device-Deaktivierung schützt nicht gegen Seed-Kompromittierung — siehe [Identity 001](../01-wot-identity/001-identitaet-und-schluesselableitung.md#multi-device--shared-seed-modell). Für echten Schutz muss die Identität rotiert werden.
 
@@ -145,7 +145,7 @@ Malformed `device-revoke` Nachrichten werden mit `MALFORMED_MESSAGE` abgelehnt. 
 
 Der Broker speichert pro DID mindestens `deviceId`, `firstSeenAt`, `lastSeenAt`, `status` (`active` oder `revoked`) und optional `revokedAt`. Diese Liste ist Broker-Metadatum und liegt im Klartext vor.
 
-`active` und `revoked` sind die einzigen normativen Device-Statuswerte in `wot-sync@0.1`. Ein `revoked` Record ist ein Tombstone: solange der Broker ihn speichert, gilt die `deviceId` weiter als registriert und reserviert fuer Konfliktpruefungen. Eine fuer eine andere DID retained revoked `deviceId` fuehrt daher weiterhin zu `DEVICE_ID_CONFLICT`.
+`active` und `revoked` sind die einzigen normativen Device-Statuswerte in `wot-sync@0.1`. Ein `revoked` Record ist ein Tombstone: solange der Broker ihn speichert, gilt die `deviceId` weiter als registriert und reserviert für Konfliktprüfungen. Eine für eine andere DID retained revoked `deviceId` führt daher weiterhin zu `DEVICE_ID_CONFLICT`.
 
 ### Race Conditions
 
@@ -332,7 +332,7 @@ Persistente WoT-Objekte (Attestation-JWS, Capability-JWS, Log-Entry-JWS, verschl
 | `pthid` | UUID v4 | Optional | Parent-Thread-ID. Verweist auf einen übergeordneten Thread — für verschachtelte Konversationen (z.B. ein Sub-Protokoll das innerhalb eines größeren Flows läuft). |
 | `body` | Object | Ja | Nachrichteninhalt. Struktur abhängig vom `type`. |
 
-Das generische Plaintext-Envelope-Format DARF `to` weglassen, wenn der konkrete Nachrichtentyp seine Empfaenger aus dem authentifizierten Transportkontext oder aus dem Body ableitet, z.B. bei Broker-gebundenen `sync-request`/`sync-response` Nachrichten. Konkrete Nachrichtentypen DUERFEN strengere Regeln definieren. Inbox- und direkt adressierte Nachrichten MUESSEN `to` setzen.
+Das generische Plaintext-Envelope-Format DARF `to` weglassen, wenn der konkrete Nachrichtentyp seine Empfänger aus dem authentifizierten Transportkontext oder aus dem Body ableitet, z.B. bei Broker-gebundenen `sync-request`/`sync-response` Nachrichten. Konkrete Nachrichtentypen DÜRFEN strengere Regeln definieren. Inbox- und direkt adressierte Nachrichten MÜSSEN `to` setzen.
 
 ### Autoritätsgrenze (MUSS)
 
@@ -576,9 +576,9 @@ Normative Error-Codes:
 | `DEVICE_REVOKED` | Device-ID ist als revoked markiert |
 | `DEVICE_ID_CONFLICT` | Device-ID bereits für eine andere DID registriert |
 | `SEQ_COLLISION_DETECTED` | Log-Eintrag mit `(docId, deviceId, seq)` existiert bereits mit anderem Content-Hash — Client MUSS neue `deviceId` generieren (Restore/Clone-Szenario) |
-| `MALFORMED_MESSAGE` | Nachricht oder Pflichtfeld ist syntaktisch ungueltig, inklusive malformed DID, malformed UUID v4 `deviceId`, malformed Base64URL-Nonce oder fehlender Pflichtfelder |
-| `AUTH_INVALID` | Challenge-Response, Envelope-JWS oder Device-Revocation-Signatur ist ungueltig oder passt nicht zu DID, Device oder ausstehender Challenge |
-| `NONCE_REPLAY` | Broker-Challenge-Nonce wurde bereits akzeptiert oder ist nicht mehr als ausstehende Challenge gueltig |
+| `MALFORMED_MESSAGE` | Nachricht oder Pflichtfeld ist syntaktisch ungültig, inklusive JSON-Parse-Fehler, malformed DID, malformed UUID v4 `deviceId`, malformed Base64URL-Nonce oder fehlender Pflichtfelder |
+| `AUTH_INVALID` | Challenge-Response, Envelope-JWS oder Device-Revocation-Signatur ist ungültig oder passt nicht zu DID, Device oder ausstehender Challenge |
+| `NONCE_REPLAY` | Broker-Challenge-Nonce wurde bereits akzeptiert oder ist nicht mehr als ausstehende Challenge gültig |
 | `RATE_LIMITED` | Rate-Limit überschritten |
 | `INTERNAL_ERROR` | Server-Fehler |
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -100,6 +100,8 @@ Inbox-Nachrichtentyp `space-invite`, verschlüsselt mit ECIES:
 - `spaceContentKeys` MUSS alle Generationen enthalten, die der Eingeladene zum Entschluesseln der aktuell verfuegbaren Space-History benoetigt. Implementierungen duerfen alte Generationen weglassen, wenn sie dem Eingeladenen nur Zugriff ab einem spaeteren Snapshot geben; dann MUSS dieser Snapshot mit `currentKeyGeneration` entschluesselbar sein.
 - Der `spaceCapabilitySigningKey` DARF nur zur Ausstellung weiterer Broker-Capabilities verwendet werden, nicht zur Autoren-Authentifizierung.
 
+Die Phase-1-Interop-Vektoren fuer `space-invite` pruefen das Inbox-Message-Shape. Die enthaltene `capability` wird dort nur als kompakter JWS-String validiert. Payload-Korrelation der Capability (`audience`, `spaceId`, `generation`, Signatur) ist durch den separaten `space_capability_jws` Vektor und die Capability-Regeln in [Sync 003](003-transport-und-broker.md#capability-format) abgedeckt. Spaetere Conformance-Vektoren SOLLEN echte Capability-JWS-End-to-End-Beispiele fuer `space-invite` enthalten.
+
 ### Annahme und Ablehnung
 
 Bei Annahme speichert der Empfänger Space Content Key, Space Capability Signing Key und Capability lokal, verbindet sich mit dem Heim-Broker und synchronisiert das Space-Dokument. Bei Ablehnung verwirft er die Nachricht.
@@ -287,6 +289,8 @@ Alte Daten bleiben mit alten Space Content Keys lesbar. Rotation schuetzt nur zu
 - Der Broker MUSS nach erfolgreicher `space-rotate` Verarbeitung alte Capabilities ablehnen (`CAPABILITY_GENERATION_STALE`).
 - Clients MUESSEN neue Log-Eintraege nach Rotation mit der neuen `keyGeneration` schreiben.
 - Clients MUESSEN alte Log-Eintraege weiter mit der jeweils im Log-Eintrag angegebenen historischen `keyGeneration` entschluesseln.
+
+Die Phase-1-Interop-Vektoren fuer `key-rotation` pruefen das Inbox-Message-Shape. Die enthaltene `capability` wird dort nur als kompakter JWS-String validiert. Payload-Korrelation der Capability (`audience`, `spaceId`, `generation`, Signatur) ist durch den separaten `space_capability_jws` Vektor und die Capability-Regeln in [Sync 003](003-transport-und-broker.md#capability-format) abgedeckt. Spaetere Conformance-Vektoren SOLLEN echte Capability-JWS-End-to-End-Beispiele fuer `key-rotation` enthalten.
 
 Clients MUESSEN Key-Rotations anhand ihrer lokal bekannten Space-Key-Generation anwenden:
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -100,7 +100,7 @@ Inbox-Nachrichtentyp `space-invite`, verschlüsselt mit ECIES:
 - `spaceContentKeys` MUSS alle Generationen enthalten, die der Eingeladene zum Entschluesseln der aktuell verfuegbaren Space-History benoetigt. Implementierungen duerfen alte Generationen weglassen, wenn sie dem Eingeladenen nur Zugriff ab einem spaeteren Snapshot geben; dann MUSS dieser Snapshot mit `currentKeyGeneration` entschluesselbar sein.
 - Der `spaceCapabilitySigningKey` DARF nur zur Ausstellung weiterer Broker-Capabilities verwendet werden, nicht zur Autoren-Authentifizierung.
 
-Die Phase-1-Interop-Vektoren fuer `space-invite` pruefen das Inbox-Message-Shape. Die enthaltene `capability` wird dort nur als kompakter JWS-String validiert. Payload-Korrelation der Capability (`audience`, `spaceId`, `generation`, Signatur) ist durch den separaten `space_capability_jws` Vektor und die Capability-Regeln in [Sync 003](003-transport-und-broker.md#capability-format) abgedeckt. Spaetere Conformance-Vektoren SOLLEN echte Capability-JWS-End-to-End-Beispiele fuer `space-invite` enthalten.
+Die Phase-1-Interop-Vektoren für `space-invite` prüfen das Inbox-Message-Shape. Die enthaltene `capability` wird dort nur als kompakter JWS-String validiert. Payload-Korrelation der Capability (`audience`, `spaceId`, `generation`, Signatur) ist durch den separaten `space_capability_jws` Vektor und die Capability-Regeln in [Sync 003](003-transport-und-broker.md#capability-format) abgedeckt. Spätere Conformance-Vektoren SOLLEN echte Capability-JWS-End-to-End-Beispiele für `space-invite` enthalten.
 
 ### Annahme und Ablehnung
 
@@ -290,7 +290,7 @@ Alte Daten bleiben mit alten Space Content Keys lesbar. Rotation schuetzt nur zu
 - Clients MUESSEN neue Log-Eintraege nach Rotation mit der neuen `keyGeneration` schreiben.
 - Clients MUESSEN alte Log-Eintraege weiter mit der jeweils im Log-Eintrag angegebenen historischen `keyGeneration` entschluesseln.
 
-Die Phase-1-Interop-Vektoren fuer `key-rotation` pruefen das Inbox-Message-Shape. Die enthaltene `capability` wird dort nur als kompakter JWS-String validiert. Payload-Korrelation der Capability (`audience`, `spaceId`, `generation`, Signatur) ist durch den separaten `space_capability_jws` Vektor und die Capability-Regeln in [Sync 003](003-transport-und-broker.md#capability-format) abgedeckt. Spaetere Conformance-Vektoren SOLLEN echte Capability-JWS-End-to-End-Beispiele fuer `key-rotation` enthalten.
+Die Phase-1-Interop-Vektoren für `key-rotation` prüfen das Inbox-Message-Shape. Die enthaltene `capability` wird dort nur als kompakter JWS-String validiert. Payload-Korrelation der Capability (`audience`, `spaceId`, `generation`, Signatur) ist durch den separaten `space_capability_jws` Vektor und die Capability-Regeln in [Sync 003](003-transport-und-broker.md#capability-format) abgedeckt. Spätere Conformance-Vektoren SOLLEN echte Capability-JWS-End-to-End-Beispiele für `key-rotation` enthalten.
 
 Clients MUESSEN Key-Rotations anhand ihrer lokal bekannten Space-Key-Generation anwenden:
 

--- a/03-wot-sync/006-personal-doc.md
+++ b/03-wot-sync/006-personal-doc.md
@@ -192,14 +192,16 @@ Damit hat jedes Gerät des Users denselben Personal Doc Key. Es muss nichts vert
 
 ### Deterministische Document-ID
 
-Die Dokument-ID des Personal Doc wird aus dem Personal Doc Key abgeleitet:
+Die Dokument-ID des Personal Doc MUSS aus dem Personal Doc Key abgeleitet werden:
 
-```
+```text
 raw = first_16_bytes(Personal Doc Key)
-raw[6] = (raw[6] & 0x0f) | 0x40  // UUID version 4
+raw[6] = (raw[6] & 0x0f) | 0x40  // UUID version 4, RFC 9562 §5.4
 raw[8] = (raw[8] & 0x3f) | 0x80  // RFC 9562 variant
 docId = raw formatiert als kanonische lowercase UUID
 ```
+
+Diese deterministische UUID-v4-Form ist eine Wire-Format-Konvention für Interop, keine Aussage darüber, dass die nicht fixierten Bits aus einem UUID-v4-RNG stammen. JSON-Schema kann die Byte-Manipulation auf abgeleitetem Schlüsselmaterial nicht vollständig validieren; Schemas DÜRFEN nur die kanonische UUID-v4-Form prüfen. Konformität der Ableitung wird durch Testvektoren und Referenz-Validatoren geprüft.
 
 Damit hat jedes Gerät des Users dieselbe Document-ID. Der Broker speichert Log-Einträge unter dieser ID, ohne wissen zu müssen, dass es ein Personal Doc ist.
 

--- a/03-wot-sync/006-personal-doc.md
+++ b/03-wot-sync/006-personal-doc.md
@@ -195,7 +195,10 @@ Damit hat jedes Gerät des Users denselben Personal Doc Key. Es muss nichts vert
 Die Dokument-ID des Personal Doc wird aus dem Personal Doc Key abgeleitet:
 
 ```
-docId = first_16_bytes(Personal Doc Key)  → formatiert als UUID
+raw = first_16_bytes(Personal Doc Key)
+raw[6] = (raw[6] & 0x0f) | 0x40  // UUID version 4
+raw[8] = (raw[8] & 0x3f) | 0x80  // RFC 9562 variant
+docId = raw formatiert als kanonische lowercase UUID
 ```
 
 Damit hat jedes Gerät des Users dieselbe Document-ID. Der Broker speichert Log-Einträge unter dieser ID, ohne wissen zu müssen, dass es ein Personal Doc ist.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -74,7 +74,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - AES-256-GCM mit 96-Bit Nonces verwenden.
 - ECIES mit X25519, HKDF-SHA256 und AES-256-GCM fuer Inbox-Nachrichten implementieren.
 - Gruppen- und Personal-Doc-Payloads vor dem Sync verschluesseln.
-- Leere Klartexte und tag-only Ciphertexts fuer ECIES- und Log-Payloads ablehnen.
+- Implementierungen MUESSEN leere Klartexte und tag-only Ciphertexts fuer ECIES- und Log-Payloads ablehnen.
 - Die Nonce-Konstruktion des jeweiligen Dokuments einhalten.
 
 ### Log-Sync
@@ -85,7 +85,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Kollisionen fuer `(docId, deviceId, seq)` erkennen und sicher behandeln.
 - App-Start- und Reconnect-Flows gemaess Sync 002 ausfuehren: lokalen Zustand laden, Broker authentisieren, Personal Doc zuerst syncen, danach fuer Space-Dokumente ueber Heads/`sync-request` einen Catch-Up durchfuehren.
 - Lokale Schreibvorgaenge zuerst persistent als Log-Eintrag speichern und erst danach an Broker/Peers publizieren.
-- Gueltige Log-Eintraege mit vorhandener, aber lokal unbekannter `keyGeneration` als `blocked-by-key` behandeln und nach Key-Catch-Up erneut verarbeiten; malformed Log-Eintraege ohne Pflichtfeld `keyGeneration` ablehnen.
+- Implementierungen MUESSEN gueltige Log-Eintraege mit vorhandener, aber lokal unbekannter `keyGeneration` als `blocked-by-key` behandeln und nach Key-Catch-Up erneut verarbeiten; malformed Log-Eintraege ohne Pflichtfeld `keyGeneration` MUESSEN abgelehnt werden.
 - Snapshots und Full-State-Nachrichten nur als Optimierung mergen und niemals als Ersatz fuer Log-Catch-Up oder als Rollback bekannter gueltiger Eintraege verwenden.
 
 ### Transport und Broker
@@ -93,7 +93,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - WoT Plaintext Envelopes erzeugen und parsen, deren JSON-Shape DIDComm-v2-Plaintext-kompatibel ist und `typ: "application/didcomm-plain+json"` setzt.
 - Envelope-Testvektoren mit mindestens einer etablierten DIDComm-v2-Library validieren. Diese Validierung prueft nur die Envelope-Kompatibilitaet, nicht DIDComm-JWE/Authcrypt oder DIDComm-Mediator-Protokolle.
 - WoT Envelopes nur als ephemeres Transport-Framing behandeln; persistente WoT-Objekte bleiben JWS-/Payload-Objekte im Body.
-- Broker-Challenge-Response mit DID-Signaturen ueber den strukturierten Broker-Auth-Transcript umsetzen.
+- Implementierungen MUESSEN Broker-Challenge-Response mit DID-Signaturen ueber den strukturierten Broker-Auth-Transcript umsetzen.
 - Capabilities als JWS verifizieren.
 - Inbox-Nachrichten pro Device zustellen und ACKs verarbeiten.
 - Selbstadressierte Inbox-Nachrichten an andere Devices derselben DID zustellen, ohne das sendende Device als erfolgreich zugestellten Empfaenger zu behandeln.

--- a/CONFORMANCE.md
+++ b/CONFORMANCE.md
@@ -74,6 +74,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - AES-256-GCM mit 96-Bit Nonces verwenden.
 - ECIES mit X25519, HKDF-SHA256 und AES-256-GCM fuer Inbox-Nachrichten implementieren.
 - Gruppen- und Personal-Doc-Payloads vor dem Sync verschluesseln.
+- Leere Klartexte und tag-only Ciphertexts fuer ECIES- und Log-Payloads ablehnen.
 - Die Nonce-Konstruktion des jeweiligen Dokuments einhalten.
 
 ### Log-Sync
@@ -84,7 +85,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - Kollisionen fuer `(docId, deviceId, seq)` erkennen und sicher behandeln.
 - App-Start- und Reconnect-Flows gemaess Sync 002 ausfuehren: lokalen Zustand laden, Broker authentisieren, Personal Doc zuerst syncen, danach fuer Space-Dokumente ueber Heads/`sync-request` einen Catch-Up durchfuehren.
 - Lokale Schreibvorgaenge zuerst persistent als Log-Eintrag speichern und erst danach an Broker/Peers publizieren.
-- Log-Eintraege mit fehlender `keyGeneration` als `blocked-by-key` behandeln und nach Key-Catch-Up erneut verarbeiten.
+- Gueltige Log-Eintraege mit vorhandener, aber lokal unbekannter `keyGeneration` als `blocked-by-key` behandeln und nach Key-Catch-Up erneut verarbeiten; malformed Log-Eintraege ohne Pflichtfeld `keyGeneration` ablehnen.
 - Snapshots und Full-State-Nachrichten nur als Optimierung mergen und niemals als Ersatz fuer Log-Catch-Up oder als Rollback bekannter gueltiger Eintraege verwenden.
 
 ### Transport und Broker
@@ -92,7 +93,7 @@ Eine Implementierung ist `wot-sync@0.1`-konform, wenn sie zusaetzlich `wot-ident
 - WoT Plaintext Envelopes erzeugen und parsen, deren JSON-Shape DIDComm-v2-Plaintext-kompatibel ist und `typ: "application/didcomm-plain+json"` setzt.
 - Envelope-Testvektoren mit mindestens einer etablierten DIDComm-v2-Library validieren. Diese Validierung prueft nur die Envelope-Kompatibilitaet, nicht DIDComm-JWE/Authcrypt oder DIDComm-Mediator-Protokolle.
 - WoT Envelopes nur als ephemeres Transport-Framing behandeln; persistente WoT-Objekte bleiben JWS-/Payload-Objekte im Body.
-- Broker-Challenge-Response mit DID-Signaturen umsetzen.
+- Broker-Challenge-Response mit DID-Signaturen ueber den strukturierten Broker-Auth-Transcript umsetzen.
 - Capabilities als JWS verifizieren.
 - Inbox-Nachrichten pro Device zustellen und ACKs verarbeiten.
 - Selbstadressierte Inbox-Nachrichten an andere Devices derselben DID zustellen, ohne das sendende Device als erfolgreich zugestellten Empfaenger zu behandeln.

--- a/schemas/capability-payload.schema.json
+++ b/schemas/capability-payload.schema.json
@@ -7,7 +7,7 @@
   "additionalProperties": false,
   "properties": {
     "type": { "const": "capability" },
-    "spaceId": { "type": "string", "format": "uuid" },
+    "spaceId": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "audience": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
     "permissions": {
       "type": "array",

--- a/schemas/didcomm-plaintext-message.schema.json
+++ b/schemas/didcomm-plaintext-message.schema.json
@@ -6,7 +6,7 @@
   "required": ["id", "typ", "type", "from", "created_time", "body"],
   "additionalProperties": true,
   "properties": {
-    "id": { "type": "string", "format": "uuid" },
+    "id": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "typ": { "const": "application/didcomm-plain+json" },
     "type": { "type": "string", "format": "uri" },
     "from": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },

--- a/schemas/key-rotation.schema.json
+++ b/schemas/key-rotation.schema.json
@@ -6,7 +6,7 @@
   "required": ["id", "typ", "type", "from", "to", "created_time", "body"],
   "additionalProperties": true,
   "properties": {
-    "id": { "type": "string", "format": "uuid" },
+    "id": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "typ": { "const": "application/didcomm-plain+json" },
     "type": { "const": "https://web-of-trust.de/protocols/key-rotation/1.0" },
     "from": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
@@ -16,14 +16,14 @@
       "items": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" }
     },
     "created_time": { "type": "integer", "minimum": 0 },
-    "thid": { "type": "string", "format": "uuid" },
-    "pthid": { "type": "string", "format": "uuid" },
+    "thid": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
+    "pthid": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "body": {
       "type": "object",
       "required": ["spaceId", "generation", "spaceContentKey", "spaceCapabilitySigningKey", "capability"],
       "additionalProperties": false,
       "properties": {
-        "spaceId": { "type": "string", "format": "uuid" },
+        "spaceId": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
         "generation": { "type": "integer", "minimum": 0 },
         "spaceContentKey": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },
         "spaceCapabilitySigningKey": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },

--- a/schemas/log-entry-payload.schema.json
+++ b/schemas/log-entry-payload.schema.json
@@ -7,8 +7,8 @@
   "additionalProperties": false,
   "properties": {
     "seq": { "type": "integer", "minimum": 0 },
-    "deviceId": { "type": "string", "format": "uuid" },
-    "docId": { "type": "string", "format": "uuid" },
+    "deviceId": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
+    "docId": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "authorKid": { "type": "string", "pattern": "^did:[a-z0-9]+:.+#.+$" },
     "keyGeneration": { "type": "integer", "minimum": 0 },
     "data": { "type": "string", "pattern": "^[A-Za-z0-9_-]+$" },

--- a/schemas/member-update.schema.json
+++ b/schemas/member-update.schema.json
@@ -6,7 +6,7 @@
   "required": ["id", "typ", "type", "from", "to", "created_time", "body"],
   "additionalProperties": true,
   "properties": {
-    "id": { "type": "string", "format": "uuid" },
+    "id": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "typ": { "const": "application/didcomm-plain+json" },
     "type": { "const": "https://web-of-trust.de/protocols/member-update/1.0" },
     "from": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
@@ -16,14 +16,14 @@
       "items": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" }
     },
     "created_time": { "type": "integer", "minimum": 0 },
-    "thid": { "type": "string", "format": "uuid" },
-    "pthid": { "type": "string", "format": "uuid" },
+    "thid": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
+    "pthid": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "body": {
       "type": "object",
       "required": ["spaceId", "action", "memberDid", "effectiveKeyGeneration"],
       "additionalProperties": false,
       "properties": {
-        "spaceId": { "type": "string", "format": "uuid" },
+        "spaceId": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
         "action": { "enum": ["added", "removed"] },
         "memberDid": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
         "effectiveKeyGeneration": { "type": "integer", "minimum": 0 },

--- a/schemas/space-invite.schema.json
+++ b/schemas/space-invite.schema.json
@@ -6,7 +6,7 @@
   "required": ["id", "typ", "type", "from", "to", "created_time", "body"],
   "additionalProperties": true,
   "properties": {
-    "id": { "type": "string", "format": "uuid" },
+    "id": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "typ": { "const": "application/didcomm-plain+json" },
     "type": { "const": "https://web-of-trust.de/protocols/space-invite/1.0" },
     "from": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
@@ -16,14 +16,14 @@
       "items": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" }
     },
     "created_time": { "type": "integer", "minimum": 0 },
-    "thid": { "type": "string", "format": "uuid" },
-    "pthid": { "type": "string", "format": "uuid" },
+    "thid": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
+    "pthid": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
     "body": {
       "type": "object",
       "required": ["spaceId", "brokerUrls", "currentKeyGeneration", "spaceContentKeys", "spaceCapabilitySigningKey", "adminDids", "capability"],
       "additionalProperties": false,
       "properties": {
-        "spaceId": { "type": "string", "format": "uuid" },
+        "spaceId": { "type": "string", "format": "uuid", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$" },
         "brokerUrls": {
           "type": "array",
           "minItems": 1,

--- a/scripts/validate_test_vectors.py
+++ b/scripts/validate_test_vectors.py
@@ -115,6 +115,15 @@ def did_key_ed(public_key: bytes) -> str:
     return "did:key:z" + b58encode(bytes.fromhex("ed01") + public_key)
 
 
+def uuid_v4_from_bytes(value: bytes) -> str:
+    if len(value) != 16:
+        raise ValueError("uuid value must be 16 bytes")
+    raw = bytearray(value)
+    raw[6] = (raw[6] & 0x0F) | 0x40
+    raw[8] = (raw[8] & 0x3F) | 0x80
+    return f"{raw[:4].hex()}-{raw[4:6].hex()}-{raw[6:8].hex()}-{raw[8:10].hex()}-{raw[10:].hex()}"
+
+
 def multibase_ed(public_key: bytes) -> str:
     return "z" + b58encode(bytes.fromhex("ed01") + public_key)
 
@@ -273,8 +282,7 @@ def main() -> None:
     personal = data["personal_doc"]
     personal_key = hkdf(seed, personal["hkdf_info"])
     assert personal_key.hex() == personal["key_hex"]
-    raw_doc = personal_key[:16]
-    doc_id = f"{raw_doc[:4].hex()}-{raw_doc[4:6].hex()}-{raw_doc[6:8].hex()}-{raw_doc[8:10].hex()}-{raw_doc[10:].hex()}"
+    doc_id = uuid_v4_from_bytes(personal_key[:16])
     assert doc_id == personal["doc_id"]
     print("personal doc ok")
 

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -421,7 +421,7 @@
   "personal_doc": {
     "hkdf_info": "wot/personal-doc/v1",
     "key_hex": "ed3b3cbec944063041a15cf14be4c2aecd87ec30f2085cd9f2f82333cfcd437c",
-    "doc_id": "ed3b3cbe-c944-0630-41a1-5cf14be4c2ae"
+    "doc_id": "ed3b3cbe-c944-4630-81a1-5cf14be4c2ae"
   },
   "sd_jwt_vc_trust_list": {
     "disclosure": [

--- a/test-vectors/phase-1-interop.md
+++ b/test-vectors/phase-1-interop.md
@@ -189,7 +189,7 @@ Admin DID: did:key:z6MkvLMiE11z8wXjNScxqjcMJHNfNyc8XqDT4aGzry4pFTTd
 ```
 HKDF Info: wot/personal-doc/v1
 Personal Doc Key: ed3b3cbec944063041a15cf14be4c2aecd87ec30f2085cd9f2f82333cfcd437c
-Document-ID: ed3b3cbe-c944-0630-41a1-5cf14be4c2ae
+Document-ID: ed3b3cbe-c944-4630-81a1-5cf14be4c2ae
 ```
 
 ## 11. SD-JWT VC Trust List (H01/H03)


### PR DESCRIPTION
## Summary
- Clarifies canonical lowercase UUID v4 use for sync IDs, deterministic Personal Doc IDs, broker device IDs, and related schemas/vectors.
- Clarifies broker auth transcript signing, device revoke tombstones/idempotency, optional envelope `to`, snapshot scope, blocked-by-key handling, and device status semantics.
- Documents empty-plaintext rejection for ECIES/log payload encryption and keeps phase-1 invite/rotation vectors shape-only with capability correlation covered separately.

## Issues
Closes real-life-org/wot-spec#23
Closes real-life-org/wot-spec#24
Closes real-life-org/wot-spec#25
Closes real-life-org/wot-spec#26
Closes real-life-org/wot-spec#27
Closes real-life-org/wot-spec#28
Closes real-life-org/wot-spec#29
Closes real-life-org/wot-spec#30
Closes real-life-org/wot-spec#31
Closes real-life-org/wot-spec#32
Closes real-life-org/wot-spec#33

## Validation
- `git diff --check`
- `npm run validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced canonical UUIDv4 formatting for device, document, and message IDs.
  * Tightened encryption checks to reject empty plaintexts and malformed/tag-only ciphertexts.
  * Made sync log handling more robust: malformed/unknown-generation entries are rejected or preserved for reprocessing as appropriate.

* **Documentation**
  * Clarified protocol, conformance, and broker-auth requirements and added interoperability vectors and updated test vectors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->