### PR TITLE
Add offline spec consistency harness

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,14 +28,8 @@ jobs:
       - name: Install Node dependencies
         run: npm install --no-package-lock
 
-      - name: Validate JSON Schemas and examples
-        run: npm run validate:schemas
-
-      - name: Validate test vectors
-        run: npm run validate:vectors
-
-      - name: Validate DIDComm envelope compatibility
-        run: npm run validate:didcomm
+      - name: Validate spec
+        run: npm run validate
 
       - name: Check whitespace
         run: git diff --check

--- a/docs/automation/spec-consistency-harness.md
+++ b/docs/automation/spec-consistency-harness.md
@@ -12,7 +12,7 @@ The harness validates:
 - manifest test-vector sections and library-check sections exist as top-level keys in the referenced vector JSON;
 - local Markdown links and anchors in conformance docs, automation docs, test-vector documentation, and manifest-referenced spec documents resolve locally.
 
-The harness contains a narrow baseline for pre-existing broken anchors in normative documents that this automation-only slice cannot edit. Those entries are reported as `known anchor drift` and should be removed from the baseline when a separate normative cleanup PR fixes the links.
+The harness contains a narrow baseline for pre-existing broken anchors in normative documents that this automation-only slice cannot edit. Those entries are reported as `known anchor drift`, tracked in wot-spec#58, and should be removed from the baseline when a separate normative cleanup PR fixes the links.
 
 The harness reports open clarification markers such as `TODO`, `FIXME`, `TBD`, `Offene`, and `wot-spec#NN` as informational output only. These markers are useful during draft work, but the offline harness does not look up issue state.
 

--- a/docs/automation/spec-consistency-harness.md
+++ b/docs/automation/spec-consistency-harness.md
@@ -1,0 +1,21 @@
+# Spec Consistency Harness
+
+`npm run validate:consistency` runs an offline consistency harness for repository-local spec artifacts. It does not call GitHub, package registries, or any network service.
+
+The harness validates:
+
+- all local JSON files parse successfully;
+- every profile id in `conformance/manifest.json` is mentioned in `CONFORMANCE.md`;
+- manifest profile dependencies point to known profiles;
+- manifest spec documents, schema references, test-vector files, and library-check files exist locally;
+- every schema has one valid and one invalid example file;
+- manifest test-vector sections and library-check sections exist as top-level keys in the referenced vector JSON;
+- local Markdown links and anchors in conformance docs, automation docs, test-vector documentation, and manifest-referenced spec documents resolve locally.
+
+The harness contains a narrow baseline for pre-existing broken anchors in normative documents that this automation-only slice cannot edit. Those entries are reported as `known anchor drift` and should be removed from the baseline when a separate normative cleanup PR fixes the links.
+
+The harness reports open clarification markers such as `TODO`, `FIXME`, `TBD`, `Offene`, and `wot-spec#NN` as informational output only. These markers are useful during draft work, but the offline harness does not look up issue state.
+
+The harness deliberately does not validate cryptographic correctness, JSON Schema semantics, DIDComm library compatibility, or vector derivation. Those checks remain covered by the dedicated validators in `npm run validate`.
+
+Future consistency checks should detect drift between existing artifacts without silently changing normative behavior. If a proposed check would require new protocol requirements, new wire-format constraints, or stricter conformance claims, make that change in a separate normative PR and update schemas, vectors, `CONFORMANCE.md`, and `conformance/manifest.json` deliberately.

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
   "type": "module",
   "scripts": {
     "conformance": "npm run validate",
-    "validate": "npm run validate:conformance && npm run validate:schemas && npm run validate:vectors && npm run validate:didcomm",
+    "validate": "npm run validate:conformance && npm run validate:schemas && npm run validate:vectors && npm run validate:consistency && npm run validate:didcomm",
     "validate:conformance": "python3 scripts/validate_conformance_manifest.py",
     "validate:schemas": "python3 scripts/validate_schemas.py",
     "validate:vectors": "python3 scripts/validate_test_vectors.py",
-    "validate:didcomm": "node scripts/validate_didcomm_envelope.mjs"
+    "validate:didcomm": "node scripts/validate_didcomm_envelope.mjs",
+    "validate:consistency": "python3 scripts/validate_spec_consistency.py"
   },
   "devDependencies": {
     "@veramo/did-comm": "7.0.0",

--- a/scripts/validate_spec_consistency.py
+++ b/scripts/validate_spec_consistency.py
@@ -20,8 +20,8 @@ INFO_MARKER_RE = re.compile(r"\b(?:TODO|FIXME|TBD|Offene|offene|Klaer|Klär)\b|w
 
 # Baseline for pre-existing normative spec anchor drift found when this
 # offline harness was introduced. This slice may not edit normative spec
-# files, so these links remain informational until a separate spec cleanup
-# PR fixes them deliberately.
+# files, so these links remain informational until wot-spec#58 fixes them
+# deliberately in a separate cleanup PR.
 KNOWN_ANCHOR_DRIFT = {
     ("03-wot-sync/003-transport-und-broker.md", 117, "#device-liste"),
     ("05-hmc-extensions/H03-gossip.md", 36, "../03-wot-sync/003-transport-und-broker.md#message-envelope-didcomm-kompatibel"),

--- a/scripts/validate_spec_consistency.py
+++ b/scripts/validate_spec_consistency.py
@@ -143,7 +143,15 @@ def validate_manifest(state: CheckState) -> dict:
         state.fail("conformance manifest must define profiles")
         return manifest
 
-    conformance_text = CONFORMANCE.read_text(encoding="utf-8")
+    if not CONFORMANCE.is_file():
+        state.fail("missing local file: CONFORMANCE.md")
+        conformance_text = ""
+    else:
+        try:
+            conformance_text = CONFORMANCE.read_text(encoding="utf-8")
+        except OSError as exc:
+            state.fail(f"cannot read file: CONFORMANCE.md: {exc}")
+            conformance_text = ""
     profile_ids = set(profiles)
     for profile_id, profile in sorted(profiles.items()):
         if profile_id not in conformance_text:
@@ -181,7 +189,12 @@ def require_file(relative_path: str, state: CheckState) -> Path | None:
     if not isinstance(relative_path, str):
         state.fail(f"file reference must be a string: {relative_path!r}")
         return None
-    path = ROOT / relative_path
+    path = (ROOT / relative_path).resolve()
+    try:
+        path.relative_to(ROOT)
+    except ValueError:
+        state.fail(f"file reference escapes repository: {relative_path}")
+        return None
     if not path.is_file():
         state.fail(f"missing local file: {relative_path}")
         return None
@@ -240,6 +253,7 @@ def validate_library_check(check: object, state: CheckState) -> None:
         return
     data = load_json(vector_path, state)
     if not isinstance(data, dict):
+        state.fail(f"library check file must be a JSON object: {vector_file}")
         return
     if section not in data:
         state.fail(f"missing library check section {section!r} in {vector_file}")

--- a/scripts/validate_spec_consistency.py
+++ b/scripts/validate_spec_consistency.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+import json
+import re
+import sys
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CONFORMANCE = ROOT / "CONFORMANCE.md"
+MANIFEST = ROOT / "conformance" / "manifest.json"
+SCHEMAS = ROOT / "schemas"
+VALID_EXAMPLES = SCHEMAS / "examples" / "valid"
+INVALID_EXAMPLES = SCHEMAS / "examples" / "invalid"
+
+MARKDOWN_LINK_RE = re.compile(r"(?<!!)\[[^\]]+\]\(([^)\s]+)(?:\s+\"[^\"]*\")?\)")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
+HTML_ANCHOR_RE = re.compile(r"<a\s+(?:[^>]*?\s+)?(?:id|name)=[\"']([^\"']+)[\"']", re.IGNORECASE)
+INFO_MARKER_RE = re.compile(r"\b(?:TODO|FIXME|TBD|Offene|offene|Klaer|Klär)\b|wot-spec#\d+")
+
+# Baseline for pre-existing normative spec anchor drift found when this
+# offline harness was introduced. This slice may not edit normative spec
+# files, so these links remain informational until a separate spec cleanup
+# PR fixes them deliberately.
+KNOWN_ANCHOR_DRIFT = {
+    ("03-wot-sync/003-transport-und-broker.md", 117, "#device-liste"),
+    ("05-hmc-extensions/H03-gossip.md", 36, "../03-wot-sync/003-transport-und-broker.md#message-envelope-didcomm-kompatibel"),
+}
+
+
+class CheckState:
+    def __init__(self) -> None:
+        self.errors: list[str] = []
+        self.info: list[str] = []
+
+    def fail(self, message: str) -> None:
+        self.errors.append(message)
+
+    def note(self, message: str) -> None:
+        self.info.append(message)
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def load_json(path: Path, state: CheckState):
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        state.fail(f"invalid JSON: {rel(path)}:{exc.lineno}:{exc.colno}: {exc.msg}")
+    except OSError as exc:
+        state.fail(f"cannot read JSON: {rel(path)}: {exc}")
+    return None
+
+
+def iter_json_files() -> list[Path]:
+    ignored_parts = {".git", "node_modules"}
+    return sorted(
+        path
+        for path in ROOT.rglob("*.json")
+        if not ignored_parts.intersection(path.relative_to(ROOT).parts)
+    )
+
+
+def slugify_heading(heading: str) -> str:
+    heading = re.sub(r"<[^>]+>", "", heading)
+    heading = re.sub(r"\[([^\]]+)\]\([^)]+\)", r"\1", heading)
+    heading = heading.replace("`", "")
+    chars = []
+    for char in heading.strip().lower():
+        if char.isalnum() or char in {" ", "-"}:
+            chars.append(char)
+    slug = "".join("-" if char.isspace() else char for char in chars).strip("-")
+    return slug
+
+
+def markdown_anchors(path: Path) -> set[str]:
+    text = path.read_text(encoding="utf-8")
+    anchors: set[str] = set()
+    seen: dict[str, int] = {}
+    for line in text.splitlines():
+        for explicit in HTML_ANCHOR_RE.findall(line):
+            anchors.add(explicit)
+        match = HEADING_RE.match(line)
+        if not match:
+            continue
+        slug = slugify_heading(match.group(2))
+        if not slug:
+            continue
+        count = seen.get(slug, 0)
+        seen[slug] = count + 1
+        anchors.add(slug if count == 0 else f"{slug}-{count}")
+    return anchors
+
+
+def is_external_link(target: str) -> bool:
+    return bool(re.match(r"^[a-z][a-z0-9+.-]*:", target)) or target.startswith("#") is False and target.startswith("//")
+
+
+def split_local_link(target: str) -> tuple[str, str | None]:
+    path_part, _, anchor = target.partition("#")
+    path_part = unquote(path_part.split("?", 1)[0])
+    return path_part, unquote(anchor) if anchor else None
+
+
+def validate_markdown_links(paths: list[Path], state: CheckState) -> None:
+    anchor_cache: dict[Path, set[str]] = {}
+    for source in paths:
+        text = source.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            for target in MARKDOWN_LINK_RE.findall(line):
+                if is_external_link(target):
+                    continue
+                path_part, anchor = split_local_link(target)
+                target_path = (source.parent / path_part).resolve() if path_part else source
+                try:
+                    target_path.relative_to(ROOT)
+                except ValueError:
+                    state.fail(f"local markdown link escapes repository: {rel(source)}:{line_number}: {target}")
+                    continue
+                if not target_path.exists():
+                    state.fail(f"broken local markdown link: {rel(source)}:{line_number}: {target}")
+                    continue
+                if anchor and target_path.suffix == ".md":
+                    anchors = anchor_cache.setdefault(target_path, markdown_anchors(target_path))
+                    if anchor not in anchors:
+                        key = (rel(source), line_number, target)
+                        if key in KNOWN_ANCHOR_DRIFT:
+                            state.note(f"known anchor drift: {rel(source)}:{line_number}: {target}")
+                            continue
+                        state.fail(f"broken local markdown anchor: {rel(source)}:{line_number}: {target}")
+
+
+def validate_manifest(state: CheckState) -> dict:
+    manifest = load_json(MANIFEST, state)
+    if not isinstance(manifest, dict):
+        state.fail("conformance/manifest.json must be a JSON object")
+        return {}
+
+    profiles = manifest.get("profiles")
+    if not isinstance(profiles, dict) or not profiles:
+        state.fail("conformance manifest must define profiles")
+        return manifest
+
+    conformance_text = CONFORMANCE.read_text(encoding="utf-8")
+    profile_ids = set(profiles)
+    for profile_id, profile in sorted(profiles.items()):
+        if profile_id not in conformance_text:
+            state.fail(f"manifest profile id absent from CONFORMANCE.md: {profile_id}")
+        if not isinstance(profile, dict):
+            state.fail(f"profile must be an object: {profile_id}")
+            continue
+        for required in require_list(profile.get("requires", []), f"requires for {profile_id}", state):
+            if required not in profile_ids:
+                state.fail(f"profile {profile_id} requires unknown profile {required}")
+        for doc in require_list(profile.get("spec_documents", []), f"spec_documents for {profile_id}", state):
+            require_file(doc, state)
+        for schema in require_list(profile.get("schemas", []), f"schemas for {profile_id}", state):
+            validate_schema_reference(schema, state)
+        for vector_ref in require_list(profile.get("test_vectors", []), f"test_vectors for {profile_id}", state):
+            validate_vector_reference(vector_ref, state)
+        for check in require_list(profile.get("library_checks", []), f"library_checks for {profile_id}", state):
+            validate_library_check(check, state)
+
+    for validator in require_list(manifest.get("validators", []), "validators", state):
+        if not isinstance(validator, dict) or not validator.get("name") or not validator.get("command"):
+            state.fail("validators entries need name and command")
+
+    return manifest
+
+
+def require_list(value, label: str, state: CheckState) -> list:
+    if not isinstance(value, list):
+        state.fail(f"{label} must be a list")
+        return []
+    return value
+
+
+def require_file(relative_path: str, state: CheckState) -> Path | None:
+    if not isinstance(relative_path, str):
+        state.fail(f"file reference must be a string: {relative_path!r}")
+        return None
+    path = ROOT / relative_path
+    if not path.is_file():
+        state.fail(f"missing local file: {relative_path}")
+        return None
+    return path
+
+
+def validate_schema_reference(relative_path: str, state: CheckState) -> None:
+    path = require_file(relative_path, state)
+    if path is None:
+        return
+    if not path.name.endswith(".schema.json"):
+        state.fail(f"schema reference must end with .schema.json: {relative_path}")
+        return
+    example_name = path.name.replace(".schema.json", ".json")
+    for root in (VALID_EXAMPLES, INVALID_EXAMPLES):
+        example = root / example_name
+        if not example.is_file():
+            state.fail(f"missing schema example for {relative_path}: {rel(example)}")
+
+
+def validate_all_schema_examples(state: CheckState) -> None:
+    for schema in sorted(SCHEMAS.glob("*.schema.json")):
+        example_name = schema.name.replace(".schema.json", ".json")
+        for root in (VALID_EXAMPLES, INVALID_EXAMPLES):
+            example = root / example_name
+            if not example.is_file():
+                state.fail(f"missing schema example for {rel(schema)}: {rel(example)}")
+
+
+def validate_vector_reference(vector_ref: object, state: CheckState) -> None:
+    if not isinstance(vector_ref, dict):
+        state.fail("test_vectors entries must be objects")
+        return
+    vector_file = vector_ref.get("file")
+    vector_path = require_file(vector_file, state)
+    sections = require_list(vector_ref.get("sections"), f"test vector sections for {vector_file}", state)
+    if vector_path is None:
+        return
+    data = load_json(vector_path, state)
+    if not isinstance(data, dict):
+        state.fail(f"test vector file must be a JSON object: {vector_file}")
+        return
+    for section in sections:
+        if section not in data:
+            state.fail(f"missing test vector section {section!r} in {vector_file}")
+
+
+def validate_library_check(check: object, state: CheckState) -> None:
+    if not isinstance(check, dict):
+        state.fail("library_checks entries must be objects")
+        return
+    vector_file = check.get("file")
+    vector_path = require_file(vector_file, state)
+    section = check.get("section")
+    if vector_path is None:
+        return
+    data = load_json(vector_path, state)
+    if not isinstance(data, dict):
+        return
+    if section not in data:
+        state.fail(f"missing library check section {section!r} in {vector_file}")
+        return
+    require_list(check.get("libraries"), f"libraries for {section}", state)
+
+
+def collect_markdown_refs(manifest: dict) -> list[Path]:
+    paths = {CONFORMANCE, ROOT / "test-vectors" / "README.md"}
+    paths.update(sorted((ROOT / "docs" / "automation").glob("*.md")))
+    profiles = manifest.get("profiles") if isinstance(manifest, dict) else {}
+    if isinstance(profiles, dict):
+        for profile in profiles.values():
+            if not isinstance(profile, dict):
+                continue
+            for doc in profile.get("spec_documents", []):
+                if isinstance(doc, str):
+                    path = ROOT / doc
+                    if path.exists():
+                        paths.add(path)
+    return sorted(paths)
+
+
+def report_info_markers(paths: list[Path], state: CheckState) -> None:
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if INFO_MARKER_RE.search(line):
+                state.note(f"info marker: {rel(path)}:{line_number}: {line.strip()}")
+
+
+def main() -> int:
+    state = CheckState()
+
+    for path in iter_json_files():
+        load_json(path, state)
+
+    manifest = validate_manifest(state)
+    validate_all_schema_examples(state)
+
+    markdown_paths = collect_markdown_refs(manifest)
+    validate_markdown_links(markdown_paths, state)
+    report_info_markers(markdown_paths, state)
+
+    for message in state.info:
+        print(message)
+
+    if state.errors:
+        for message in state.errors:
+            print(f"ERROR: {message}", file=sys.stderr)
+        return 1
+
+    print(
+        "spec consistency ok "
+        f"({len(iter_json_files())} JSON files, {len(markdown_paths)} markdown refs)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Task

- Add offline spec consistency harness
- Generated by the local autonomous runner.
- This PR is a draft until a human decides otherwise.
- The runner must not merge this PR.
- Task kind: spec

## Spec Refs

- CONFORMANCE.md
- conformance/manifest.json
- docs/automation/spec-agent-flow.md
- docs/automation/spec-change-checklist.md
- test-vectors/README.md

## Acceptance

- Add an offline `scripts/validate_spec_consistency.py` harness that checks local consistency across `CONFORMANCE.md`, `conformance/manifest.json`, schemas, schema examples, docs, and test-vector references without calling GitHub or the network.
- The harness must fail on missing local files, broken local markdown anchors referenced from manifest/spec refs, manifest profile ids absent from `CONFORMANCE.md`, schemas without valid and invalid examples, invalid JSON files, and manifest vector references that point to missing vector files or missing top-level vector sections.
- The harness may report open clarification markers and `wot-spec#NN` references as informational output, but must not require online issue lookup.
- Add `npm run validate:consistency` and include it in `npm run validate` so the full validation command covers conformance, schemas, vectors, DIDComm, and consistency.
- Update `.github/workflows/validate.yml` to run `npm run validate` rather than a subset of validation scripts, while keeping `git diff --check`.
- Add short automation documentation explaining what the consistency harness validates, what it deliberately does not validate, and how future checks should avoid silently changing normative behavior.
- No normative spec documents, conformance manifest entries, schemas, schema examples, or test vectors are modified in this PR.

## Setup Commands

- No setup commands.

## Checks

- npm run validate
- python3 scripts/validate_spec_consistency.py
- git diff --check

## Persistent Context Refs

- AGENTS.md
- package.json
- .github/workflows/validate.yml
- scripts/validate_conformance_manifest.py
- scripts/validate_schemas.py
- scripts/validate_test_vectors.py
- scripts/validate_didcomm_envelope.mjs
- docs/automation/spec-agent-flow.md
- docs/automation/spec-change-checklist.md

## TDD

- No task-specific TDD metadata provided; behavior-changing work should still follow repository TDD rules.

## Human Gates

- No normative protocol behavior changes in this slice.
- Do not edit conformance profiles, schemas, test vectors, or spec prose.
- If the harness exposes a real inconsistency in current main, do not change normative files to make the check pass; either make the check non-fatal with a documented TODO/issue reference, create a wot-spec issue, or stop at human gate.
- GitHub issue status checks are intentionally out of scope for this offline harness.

## Residual Risk

- Dynamic run status, check results, review findings, and audit artifact paths are reported in the Agent Runner Summary comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a local repository "spec consistency" validator to detect invalid JSON, missing referenced artifacts, absent schema examples, and markdown link/anchor issues.

* **Documentation**
  * Added docs describing the consistency harness scope, reporting behavior (known anchor drift, informational markers), and explicit exclusions.

* **Chores**
  * Updated validation workflow and scripts to run the new consistency checks as part of the standard validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/real-life-org/wot-spec/pull/57)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->