### PR TITLE
Fix known normative markdown anchor drift

### DIFF
--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -114,7 +114,7 @@ Der Broker MUSS pro DID eine Liste der zugehörigen Device-IDs führen. Das ist 
 Wenn ein Client mit einer `(did, deviceId)`-Kombination verbindet, die der Broker noch nicht kennt:
 
 1. Broker führt normale Challenge-Response durch (siehe oben)
-2. Nach erfolgreicher Authentisierung: Broker prüft, ob `deviceId` bereits für eine **andere DID** registriert ist, egal ob dort `active` oder `revoked` (siehe [Device-Liste](#device-liste))
+2. Nach erfolgreicher Authentisierung: Broker prüft, ob `deviceId` bereits für eine **andere DID** registriert ist, egal ob dort `active` oder `revoked` (siehe [Device-Liste](#device-liste-im-broker))
    - Falls ja: **Ablehnen** mit `DEVICE_ID_CONFLICT` — Device-IDs MÜSSEN global eindeutig sein
 3. Broker prüft, ob `deviceId` für diese DID in einer Revocation-Liste steht
    - Falls ja: **Ablehnen** mit `DEVICE_REVOKED`

--- a/05-hmc-extensions/H03-gossip.md
+++ b/05-hmc-extensions/H03-gossip.md
@@ -33,7 +33,7 @@ Broker sieht: verschlüsselte Inbox-Nachrichten
 
 ## Nachrichtentyp: `trust-list-delta`
 
-Im Message Envelope (siehe [Sync 003](../03-wot-sync/003-transport-und-broker.md#message-envelope-didcomm-kompatibel)) wird ein neuer Typ definiert, verschlüsselt mit ECIES:
+Im Message Envelope (siehe [Sync 003](../03-wot-sync/003-transport-und-broker.md#wot-transport-envelope-didcomm-v2-kompatibel)) wird ein neuer Typ definiert, verschlüsselt mit ECIES:
 
 ```json
 {

--- a/docs/automation/spec-consistency-harness.md
+++ b/docs/automation/spec-consistency-harness.md
@@ -12,7 +12,7 @@ The harness validates:
 - manifest test-vector sections and library-check sections exist as top-level keys in the referenced vector JSON;
 - local Markdown links and anchors in conformance docs, automation docs, test-vector documentation, and manifest-referenced spec documents resolve locally.
 
-The harness contains a narrow baseline for pre-existing broken anchors in normative documents that this automation-only slice cannot edit. Those entries are reported as `known anchor drift`, tracked in wot-spec#58, and should be removed from the baseline when a separate normative cleanup PR fixes the links.
+The harness does not maintain an active anchor-drift baseline. Broken local Markdown anchors are validation errors. The initial baseline for pre-existing normative anchor drift was removed by the wot-spec#58 cleanup.
 
 The harness reports open clarification markers such as `TODO`, `FIXME`, `TBD`, `Offene`, and `wot-spec#NN` as informational output only. These markers are useful during draft work, but the offline harness does not look up issue state.
 

--- a/scripts/validate_spec_consistency.py
+++ b/scripts/validate_spec_consistency.py
@@ -18,16 +18,6 @@ HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*#*\s*$")
 HTML_ANCHOR_RE = re.compile(r"<a\s+(?:[^>]*?\s+)?(?:id|name)=[\"']([^\"']+)[\"']", re.IGNORECASE)
 INFO_MARKER_RE = re.compile(r"\b(?:TODO|FIXME|TBD|Offene|offene|Klaer|Klär)\b|wot-spec#\d+")
 
-# Baseline for pre-existing normative spec anchor drift found when this
-# offline harness was introduced. This slice may not edit normative spec
-# files, so these links remain informational until wot-spec#58 fixes them
-# deliberately in a separate cleanup PR.
-KNOWN_ANCHOR_DRIFT = {
-    ("03-wot-sync/003-transport-und-broker.md", 117, "#device-liste"),
-    ("05-hmc-extensions/H03-gossip.md", 36, "../03-wot-sync/003-transport-und-broker.md#message-envelope-didcomm-kompatibel"),
-}
-
-
 class CheckState:
     def __init__(self) -> None:
         self.errors: list[str] = []
@@ -125,10 +115,6 @@ def validate_markdown_links(paths: list[Path], state: CheckState) -> None:
                 if anchor and target_path.suffix == ".md":
                     anchors = anchor_cache.setdefault(target_path, markdown_anchors(target_path))
                     if anchor not in anchors:
-                        key = (rel(source), line_number, target)
-                        if key in KNOWN_ANCHOR_DRIFT:
-                            state.note(f"known anchor drift: {rel(source)}:{line_number}: {target}")
-                            continue
                         state.fail(f"broken local markdown anchor: {rel(source)}:{line_number}: {target}")
 
 


### PR DESCRIPTION
## Task

- Fix known normative markdown anchor drift
- Generated by the local autonomous runner.
- This PR is a draft until a human decides otherwise.
- The runner must not merge this PR.
- Task kind: spec

## Spec Refs

- https://github.com/real-life-org/wot-spec/issues/58
- 03-wot-sync/003-transport-und-broker.md
- 05-hmc-extensions/H03-gossip.md
- docs/automation/spec-consistency-harness.md
- scripts/validate_spec_consistency.py

## Acceptance

- Fix the broken `#device-liste` link in `03-wot-sync/003-transport-und-broker.md` so it points at the existing Device-Liste section anchor.
- Fix the broken `#message-envelope-didcomm-kompatibel` link in `05-hmc-extensions/H03-gossip.md` so it points at the existing WoT Transport Envelope section anchor in Sync 003.
- Remove the now-obsolete `KNOWN_ANCHOR_DRIFT` entries from `scripts/validate_spec_consistency.py`.
- Update `docs/automation/spec-consistency-harness.md` so it no longer describes an active anchor-drift baseline; it may mention that issue #58 was the cleanup that removed the initial baseline.
- Keep the PR focused on link and harness-baseline cleanup only; no normative behavior or wording changes beyond corrected local anchors.
- Reference and close wot-spec#58 in the PR summary if the cleanup is complete.

## Setup Commands

- npm install --no-package-lock

## Checks

- npm run validate
- python3 scripts/validate_spec_consistency.py
- git diff --check

## Persistent Context Refs

- package.json
- .github/workflows/validate.yml
- docs/automation/spec-consistency-harness.md
- scripts/validate_spec_consistency.py

## TDD

- No task-specific TDD metadata provided; behavior-changing work should still follow repository TDD rules.

## Human Gates

- No protocol semantics, conformance requirements, schemas, examples, or test vectors may change in this slice.
- Normative markdown files may only be edited to repair the two known anchor targets tracked by wot-spec#58.
- Remove the matching entries from `KNOWN_ANCHOR_DRIFT` only after the links are fixed and `npm run validate` is green.
- Do not introduce a new baseline or suppress a new broken-link finding.
- If the correct target heading is ambiguous, stop at human gate rather than inventing a new section name.

## Residual Risk

- Dynamic run status, check results, review findings, and audit artifact paths are reported in the Agent Runner Summary comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated internal link anchors in specification sections (transport/broker and gossip extensions) to correct reference targets.

* **Bug Fixes**
  * Validation harness tightened: broken local Markdown anchors are now reported as errors — the prior baseline that allowed known anchor drift has been removed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/real-life-org/wot-spec/pull/59)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes #58.
