### PR TITLE
Clarify Sync 003 device-revoke Control-Frame wire shape

### DIFF
--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -132,7 +132,18 @@ Wenn derselbe `(did, deviceId)` wiederkommt:
 
 ### Device-Deaktivierung
 
-Device-Deaktivierung wird über eine **signierte Revocation-Nachricht** kommuniziert:
+Device-Deaktivierung wird über einen **Broker Control-Frame** mit einem inneren signierten Revocation-Claim kommuniziert. Die exakte äußere Wire-Form ist:
+
+```json
+{
+  "type": "device-revoke",
+  "revocationJws": "<JWS Compact Serialization>"
+}
+```
+
+Der `device-revoke`-Control-Frame MUSS genau die Top-Level-Felder `type` und `revocationJws` tragen. Er DARF kein `thid`, kein `body` und keine unbekannten Top-Level-Felder tragen. Broker MÜSSEN abweichende äußere Formen mit `MALFORMED_MESSAGE` ablehnen.
+
+`revocationJws` MUSS eine JWS Compact Serialization sein. Der dekodierte JWS-Payload MUSS exakt das Device-Deaktivierungsobjekt mit den Feldern `type`, `did`, `deviceId` und `revokedAt` sein:
 
 ```json
 {
@@ -143,13 +154,14 @@ Device-Deaktivierung wird über eine **signierte Revocation-Nachricht** kommuniz
 }
 ```
 
-Signiert mit dem Identity Key der angegebenen DID. Der Broker MUSS prüfen:
+Der innere JWS-Payload DARF keine weiteren Felder tragen. Er MUSS mit dem Identity Key der angegebenen DID signiert sein. Der Broker MUSS prüfen:
 
 1. JWS-Signatur gültig gegen den Ed25519-Key aus `did`
-2. `deviceId` ist eine kanonische lowercase UUID v4 und `revokedAt` ist ein RFC3339-Date-Time mit expliziter Zeitzone
-3. Der Broker markiert `(did, deviceId)` als `revoked`
-4. Ausstehende Inbox-Nachrichten für dieses Device werden gelöscht
-5. Zukünftige Verbindungsversuche mit dieser Kombination werden mit `DEVICE_REVOKED` abgelehnt
+2. `type` im JWS-Payload ist exakt `device-revoke`
+3. `deviceId` ist eine kanonische lowercase UUID v4 und `revokedAt` ist ein RFC3339-Date-Time mit expliziter Zeitzone
+4. Der Broker markiert `(did, deviceId)` als `revoked`
+5. Ausstehende Inbox-Nachrichten für dieses Device werden gelöscht
+6. Zukünftige Verbindungsversuche mit dieser Kombination werden mit `DEVICE_REVOKED` abgelehnt
 
 Jede gültig mit dem Identity Key der DID signierte `device-revoke` Nachricht DARF jedes Device derselben DID deaktivieren. Im Shared-Seed-Modell ist keine zusätzliche Signatur eines device-spezifischen Keys erforderlich.
 
@@ -318,7 +330,7 @@ Sync 003 definiert **zwei distinkte Message-Familien** mit unterschiedlichen Env
 | Familie | Zweck | Envelope | Authentisierung | Beispiele |
 |---|---|---|---|---|
 | **WoT Transport Envelope** | Peer-zu-Peer-Nachrichten (über Broker oder direkt P2P), inklusive persistierter Inhalte und replayable Transporte | DIDComm-v2-kompatible Hülle mit `id`, `typ`, `type`, `from`, `to?`, `created_time`, `body`, `thid?`, `pthid?` | Inner-Crypto im `body` (JWS, ECIES) **oder** authentifizierter Transportkanal — siehe [Authentizität pro Message-Typ](#authentizität-pro-message-typ-normativ) | `log-entry/1.0`, `space-invite/1.0`, `member-update/1.0`, `key-rotation/1.0`, `sync-request/1.0`, `sync-response/1.0`, `ack/1.0`, `inbox/1.0` |
-| **Broker Control-Frame** | Transiente Client↔Broker-Steuernachrichten für Auth-Handshake und Fehlerrückmeldung. Nicht persistiert, nicht replayable, nicht DIDComm-kompatibel | Schlanke Form `{ type, thid?, body? }` plus typspezifische Felder | Vor dem Handshake: explizite Felder (z. B. `signature` in `challenge-response`). Nach dem Handshake: authentifizierter WebSocket-Kontext | `register`, `challenge`, `challenge-response`, `registered`, `device-revoke`, `error/1.0` |
+| **Broker Control-Frame** | Transiente Client↔Broker-Steuernachrichten für Auth-Handshake und Fehlerrückmeldung. Nicht persistiert, nicht replayable, nicht DIDComm-kompatibel | Schlanke Form `{ type, thid?, body? }` plus typspezifische Felder; `device-revoke` verwendet stattdessen die geschlossene Form `{ type, revocationJws }` | Vor dem Handshake: explizite Felder (z. B. `signature` in `challenge-response`). Nach dem Handshake: authentifizierter WebSocket-Kontext | `register`, `challenge`, `challenge-response`, `registered`, `device-revoke`, `error/1.0` |
 
 Daraus folgt normativ:
 
@@ -647,7 +659,7 @@ Control-Frame-`type` MUSS aus folgendem geschlossenem Vokabular kommen:
 | `challenge` | Broker→Client | Broker schickt Auth-Nonce | `nonce` (Base64URL) |
 | `challenge-response` | Client→Broker | Client beweist DID-Besitz | `did`, `deviceId`, `nonce`, `signature` (siehe [Wire-Encoding der signature](#wire-encoding-der-signature-muss)) |
 | `registered` | Broker→Client | Broker bestätigt erfolgreiche Auth | `did`, `deviceId`, `isNewDevice` |
-| `device-revoke` | Client→Broker | Signierter Revocation-Claim für eine Device-ID dieser DID | Innerer JWS (siehe [Device-Deaktivierung](#device-deaktivierung)) |
+| `device-revoke` | Client→Broker | Signierter Revocation-Claim für eine Device-ID dieser DID | `revocationJws`; keine weiteren Top-Level-Felder (siehe [Device-Deaktivierung](#device-deaktivierung)) |
 | `error/1.0` | Broker→Client | Fehlerrückmeldung auf eine vorherige Nachricht | `thid` (Referenz auf ursprüngliche Anfrage), `body.code`, `body.message` |
 
 Implementierungen MÜSSEN unbekannte Frame-Types als `MALFORMED_MESSAGE` ablehnen — Control-Frames sind **nicht erweiterbar** durch Drittparteien.

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -163,6 +163,8 @@ Der innere JWS-Payload DARF keine weiteren Felder tragen. Er MUSS mit dem Identi
 5. Ausstehende Inbox-Nachrichten für dieses Device werden gelöscht
 6. Zukünftige Verbindungsversuche mit dieser Kombination werden mit `DEVICE_REVOKED` abgelehnt
 
+Die Effekte aus 4-6 sind Runtime-/Protokollzustands-Prüfungen. Das Markieren von `(did, deviceId)`, die Inbox-Löschung und die Ablehnung mit `DEVICE_REVOKED` können nicht vollständig durch statische Schema- oder Vektor-Fixtures bewiesen werden; ihr Nachweis erfordert beobachtetes Broker-Laufzeitverhalten oder Protokoll-Logs.
+
 Jede gültig mit dem Identity Key der DID signierte `device-revoke` Nachricht DARF jedes Device derselben DID deaktivieren. Im Shared-Seed-Modell ist keine zusätzliche Signatur eines device-spezifischen Keys erforderlich.
 
 Eine gültige Revocation für ein unbekanntes `(did, deviceId)` MUSS der Broker als revoked Tombstone speichern und idempotent akzeptieren. Eine gültige Revocation für ein bereits revoked Device MUSS ebenfalls idempotent akzeptiert werden; die zuerst gespeicherten Revocation-Metadaten bleiben autoritativ und werden durch spätere Duplikate nicht überschrieben. Für Duplikate MUSS der Broker keine Inbox-Nachrichten erneut löschen, DARF aber dieselbe Cleanup-Operation idempotent ausführen.

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -65,6 +65,7 @@
             "log_payload_encryption",
             "log_entry_jws",
             "broker_registration_control_frames",
+            "broker_device_revoke_control_frame",
             "space_capability_jws",
             "space_membership_messages",
             "admin_key_derivation",

--- a/scripts/validate_test_vectors.py
+++ b/scripts/validate_test_vectors.py
@@ -154,6 +154,56 @@ def decode_jws(jws: str) -> tuple[dict, dict]:
     return json.loads(b64u_decode(header_b64)), json.loads(b64u_decode(payload_b64))
 
 
+def is_device_revoke_frame_shape(frame: dict) -> bool:
+    return set(frame) == {"type", "revocationJws"} and frame["type"] == "device-revoke" and isinstance(
+        frame["revocationJws"], str
+    )
+
+
+def verify_device_revoke_control_frame(vector: dict, identity: dict) -> None:
+    assert vector["identity_ref"] == "identity"
+    did = identity["did"]
+    device_id = vector["device_id"]
+    revoked_at = vector["revoked_at"]
+
+    payload = vector["payload"]
+    assert payload == {
+        "type": "device-revoke",
+        "did": did,
+        "deviceId": device_id,
+        "revokedAt": revoked_at,
+    }
+    assert set(payload) == {"type", "did", "deviceId", "revokedAt"}
+    assert re.fullmatch(
+        r"[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}", device_id
+    )
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", revoked_at)
+
+    payload_jcs = jcs(payload)
+    assert payload_jcs.decode("utf-8") == vector["payload_jcs_canonical_string"]
+    assert hashlib.sha256(payload_jcs).hexdigest() == vector["payload_jcs_sha256"]
+
+    frame = vector["frame"]
+    assert is_device_revoke_frame_shape(frame)
+    assert frame["revocationJws"] == vector["revocation_jws"]
+
+    header, decoded_payload = decode_jws(vector["revocation_jws"])
+    assert header == vector["header"]
+    assert decoded_payload == payload
+    assert set(decoded_payload) == {"type", "did", "deviceId", "revokedAt"}
+    assert vector["header"]["alg"] == "EdDSA"
+    assert vector["header"]["kid"] == identity["kid"]
+
+    header_b64, payload_b64, sig_b64 = vector["revocation_jws"].split(".")
+    assert f"{header_b64}.{payload_b64}" == vector["signing_input"]
+    assert sig_b64 == vector["signature_b64"]
+    verify_jws(vector["revocation_jws"], bytes.fromhex(identity["ed25519_public_hex"]))
+
+    for name, malformed in vector["malformed_frames"].items():
+        if is_device_revoke_frame_shape(malformed):
+            raise AssertionError(f"malformed device-revoke frame accepted: {name}")
+
+
 def verify_broker_registration_control_frames(vector: dict, identity: dict) -> None:
     assert vector["identity_ref"] == "identity"
 
@@ -326,6 +376,9 @@ def main() -> None:
 
     verify_broker_registration_control_frames(data["broker_registration_control_frames"], identity)
     print("broker registration control frames ok")
+
+    verify_device_revoke_control_frame(data["broker_device_revoke_control_frame"], identity)
+    print("broker device revoke control frame ok")
 
     cap = data["space_capability_jws"]
     cap_pub = bytes.fromhex(cap["verification_key_hex"])

--- a/scripts/validate_test_vectors.py
+++ b/scripts/validate_test_vectors.py
@@ -155,6 +155,8 @@ def decode_jws(jws: str) -> tuple[dict, dict]:
 
 
 def is_device_revoke_frame_shape(frame: dict) -> bool:
+    if not isinstance(frame, dict):
+        return False
     return set(frame) == {"type", "revocationJws"} and frame["type"] == "device-revoke" and isinstance(
         frame["revocationJws"], str
     )

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -241,8 +241,8 @@ Eine konforme Implementierung MUSS fuer die jeweils beanspruchten Profile:
 4. Fuer alle JCS-Test-Vektoren dieselben SHA-256 Hashes erzeugen.
 5. Den Attestation-VC-JWS aus den Phase-1-Interop-Vektoren verifizieren koennen.
 6. Die Phase-1-Interop-Vektoren in [`phase-1-interop.md`](phase-1-interop.md) reproduzieren koennen.
-7. Fuer `wot-sync@0.1`: den `device-revoke`-Control-Frame mit `revocationJws` akzeptieren und die malformed Frame-Formen ablehnen koennen.
-8. Fuer `wot-device-delegation@0.1`: die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
+7. Fuer `wot-sync@0.1` MUSS eine Implementierung den `device-revoke`-Control-Frame mit `revocationJws` akzeptieren und malformed Frame-Formen ablehnen.
+8. Fuer `wot-device-delegation@0.1` MUSS eine Implementierung die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und Negativfaelle ablehnen.
 
 Wenn diese Tests bestehen, ist die kryptographische Basis interoperabel.
 

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -241,7 +241,8 @@ Eine konforme Implementierung MUSS fuer die jeweils beanspruchten Profile:
 4. Fuer alle JCS-Test-Vektoren dieselben SHA-256 Hashes erzeugen.
 5. Den Attestation-VC-JWS aus den Phase-1-Interop-Vektoren verifizieren koennen.
 6. Die Phase-1-Interop-Vektoren in [`phase-1-interop.md`](phase-1-interop.md) reproduzieren koennen.
-7. Fuer `wot-device-delegation@0.1`: die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
+7. Fuer `wot-sync@0.1`: den `device-revoke`-Control-Frame mit `revocationJws` akzeptieren und die malformed Frame-Formen ablehnen koennen.
+8. Fuer `wot-device-delegation@0.1`: die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
 
 Wenn diese Tests bestehen, ist die kryptographische Basis interoperabel.
 
@@ -254,6 +255,7 @@ Die folgenden Vektoren sind in [`phase-1-interop.md`](phase-1-interop.md) dokume
 - **ECIES** - X25519 ECDH + HKDF + AES-256-GCM (Peer-to-Peer-Verschluesselung).
 - **Space Content Key** - Deterministische Nonce aus `(deviceId, seq)`, Verschluesselung/Entschluesselung.
 - **Broker Control-Frame Registrierung** - `register`/`challenge`/`challenge-response`/`registered`-Handshake mit JCS-Transcript und Ed25519-Signatur.
+- **Broker Control-Frame Device-Revoke** - geschlossener `device-revoke`-Frame mit `revocationJws`, innerem JWS-Payload und malformed Top-Level-Formen.
 - **Space Capability** - JWS-Signatur mit `spaceCapabilitySigningKey`, Broker-Verifikation.
 - **DID-Dokument** - `resolve()` fuer `did:key` plus Bootstrap-`keyAgreement`.
 - **Admin Key Ableitung** - HKDF mit Space-ID im Info-String.

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -84,6 +84,50 @@
       }
     }
   },
+  "broker_device_revoke_control_frame": {
+    "notes": "Closes wot-spec#55. Deterministic Broker Control-Frame vector for signed device-revoke. The outer frame is closed to exactly `type` and `revocationJws`; malformed examples cover forbidden thid, forbidden unknown top-level fields, and a non-JWS inline payload shape.",
+    "identity_ref": "identity",
+    "device_id": "550e8400-e29b-41d4-a716-446655440000",
+    "revoked_at": "2026-04-22T10:00:00Z",
+    "payload": {
+      "type": "device-revoke",
+      "did": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+      "deviceId": "550e8400-e29b-41d4-a716-446655440000",
+      "revokedAt": "2026-04-22T10:00:00Z"
+    },
+    "payload_jcs_canonical_string": "{\"deviceId\":\"550e8400-e29b-41d4-a716-446655440000\",\"did\":\"did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a\",\"revokedAt\":\"2026-04-22T10:00:00Z\",\"type\":\"device-revoke\"}",
+    "payload_jcs_sha256": "a41d6b564774193415db523ef609fb969788914ec7760a42c144d98ebe70b253",
+    "header": {
+      "alg": "EdDSA",
+      "kid": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a#sig-0",
+      "typ": "JWT"
+    },
+    "signing_input": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoiSldUIn0.eyJkZXZpY2VJZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsImRpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwicmV2b2tlZEF0IjoiMjAyNi0wNC0yMlQxMDowMDowMFoiLCJ0eXBlIjoiZGV2aWNlLXJldm9rZSJ9",
+    "signature_b64": "wJ8u8-OYoUXZy8yXn443WpympJEtRI_sURCi_AA95Zl2Ij7_oYIWqDISxY5aK6RCqAzJNW_oRR7RU7hfW_wrDA",
+    "revocation_jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoiSldUIn0.eyJkZXZpY2VJZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsImRpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwicmV2b2tlZEF0IjoiMjAyNi0wNC0yMlQxMDowMDowMFoiLCJ0eXBlIjoiZGV2aWNlLXJldm9rZSJ9.wJ8u8-OYoUXZy8yXn443WpympJEtRI_sURCi_AA95Zl2Ij7_oYIWqDISxY5aK6RCqAzJNW_oRR7RU7hfW_wrDA",
+    "frame": {
+      "type": "device-revoke",
+      "revocationJws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoiSldUIn0.eyJkZXZpY2VJZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsImRpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwicmV2b2tlZEF0IjoiMjAyNi0wNC0yMlQxMDowMDowMFoiLCJ0eXBlIjoiZGV2aWNlLXJldm9rZSJ9.wJ8u8-OYoUXZy8yXn443WpympJEtRI_sURCi_AA95Zl2Ij7_oYIWqDISxY5aK6RCqAzJNW_oRR7RU7hfW_wrDA"
+    },
+    "malformed_frames": {
+      "with_thid": {
+        "type": "device-revoke",
+        "thid": "550e8400-e29b-41d4-a716-446655440000",
+        "revocationJws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoiSldUIn0.eyJkZXZpY2VJZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsImRpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwicmV2b2tlZEF0IjoiMjAyNi0wNC0yMlQxMDowMDowMFoiLCJ0eXBlIjoiZGV2aWNlLXJldm9rZSJ9.wJ8u8-OYoUXZy8yXn443WpympJEtRI_sURCi_AA95Zl2Ij7_oYIWqDISxY5aK6RCqAzJNW_oRR7RU7hfW_wrDA"
+      },
+      "unknown_top_level_field": {
+        "type": "device-revoke",
+        "revocationJws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoiSldUIn0.eyJkZXZpY2VJZCI6IjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsImRpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwicmV2b2tlZEF0IjoiMjAyNi0wNC0yMlQxMDowMDowMFoiLCJ0eXBlIjoiZGV2aWNlLXJldm9rZSJ9.wJ8u8-OYoUXZy8yXn443WpympJEtRI_sURCi_AA95Zl2Ij7_oYIWqDISxY5aK6RCqAzJNW_oRR7RU7hfW_wrDA",
+        "trace": "not allowed"
+      },
+      "inline_payload_without_jws": {
+        "type": "device-revoke",
+        "did": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+        "deviceId": "550e8400-e29b-41d4-a716-446655440000",
+        "revokedAt": "2026-04-22T10:00:00Z"
+      }
+    }
+  },
   "did_resolution": {
     "did_document": {
       "id": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",


### PR DESCRIPTION
## Task

- Clarify Sync 003 device-revoke Control-Frame wire shape
- Generated by the local autonomous runner.
- This PR is a draft until a human decides otherwise.
- The runner must not merge this PR.
- Task kind: spec

## Spec Refs

- https://github.com/real-life-org/wot-spec/issues/55
- 03-wot-sync/003-transport-und-broker.md#device-deaktivierung
- 03-wot-sync/003-transport-und-broker.md#zwei-message-familien-normativ
- 03-wot-sync/003-transport-und-broker.md#authentizitaet-pro-message-typ-normativ
- 03-wot-sync/003-transport-und-broker.md#broker-control-frames-normativ
- test-vectors/phase-1-interop.json#broker_registration_control_frames
- conformance/manifest.json
- scripts/validate_test_vectors.py
- test-vectors/README.md

## Acceptance

- Resolve wot-spec#55 by normatively specifying one exact JSON Broker Control-Frame wire shape for signed `device-revoke` messages.
- Prefer the smallest shape consistent with existing Sync 003 Control-Frame style: an outer JSON object with `type: "device-revoke"` and an explicit compact-JWS carrier field, unless the surrounding spec text proves another shape is required.
- State whether `thid` is forbidden or allowed for `device-revoke`; keep the choice consistent with non-replayable Control-Frame semantics and the existing closed-frame helpers.
- State whether unknown top-level fields are forbidden for `device-revoke`, matching the closed Control-Frame vocabulary unless a specific extension rule is justified.
- State that the inner compact JWS payload is exactly the Device-Deaktivierung revocation object with `type`, `did`, `deviceId`, and `revokedAt`, signed by the Identity Key for the stated DID.
- Add or update broker-registration/control-frame test-vector material only if it can be done deterministically without changing existing unrelated vector bytes.
- If a vector is added, update `scripts/validate_test_vectors.py`, `conformance/manifest.json`, and `test-vectors/README.md` so the new valid and malformed `device-revoke` frame examples are discoverable and validated.
- Keep the PR small, reviewable, and spec-only.

## Setup Commands

- printf 'node_modules\n' > /tmp/wot-spec-runner-exclude && git config core.excludesFile /tmp/wot-spec-runner-exclude && test -e node_modules || ln -s /home/fritz/workspace/workspace/wot-spec/node_modules node_modules

## Checks

- npm run validate
- python3 scripts/validate_test_vectors.py
- python3 scripts/validate_spec_consistency.py
- git diff --check

## Persistent Context Refs

- CONFORMANCE.md
- docs/automation/spec-change-checklist.md
- docs/automation/spec-agent-flow.md
- package.json
- .github/workflows/validate.yml

## TDD

- No task-specific TDD metadata provided; behavior-changing work should still follow repository TDD rules.

## Human Gates

- Do not implement TypeScript behavior in this spec task.
- Do not change the decoded `device-revoke` payload fields or disposition semantics unless the current text is internally inconsistent.
- Do not redefine generic Broker Control-Frame behavior beyond the minimum needed to specify `device-revoke`.
- Do not close or assume unrelated open Sync issues such as inactive-device retention, broader malformed register-envelope behavior, or runtime broker persistence.
- If the exact field/nesting cannot be made unambiguous within Sync 003 only, stop at human gate and explain the remaining ambiguity.
- Do not push to `main` or any default branch.

## Residual Risk

- Dynamic run status, check results, review findings, and audit artifact paths are reported in the Agent Runner Summary comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened device-revocation control-frame spec: closed top-level shape `{type, revocationJws}`, strict inner JWS payload fields and formats, canonicalization requirements, clarified broker effects (mark device revoked, delete pending inbox messages, reject future attempts), and noted Broker Control-Frames are transient/non-DIDComm.

* **Tests**
  * Added broker device-revoke test vectors (including malformed variants) and updated conformance configuration and validation tooling to enforce strict frame parsing and signature checks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/real-life-org/wot-spec/pull/61)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->