### PR TITLE
Clarify Trust 002 Verification-Attestation jti nonce grammar

### DIFF
--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -124,7 +124,7 @@ Die Sicherheitsgarantie der Online-Verifikation ist deshalb bewusst enger defini
 Der Empfänger einer Verification-Attestation prüft:
 
 1. Ist die JWS-Signatur gültig für den `issuer`? (inklusive `alg=EdDSA` Whitelist, siehe [Identity 002](../01-wot-identity/002-signaturen-und-verifikation.md#algorithmus-validierung-muss))
-2. Enthält die Attestation-ID die aktive Challenge-Nonce?
+2. Bindet die Attestation-ID (`jti`) exakt die aktive Challenge-Nonce gemaess [Verification-Attestation](#verification-attestation)?
 3. Ist der `ts` aus der Challenge aktuell (nicht älter als 5 Minuten)?
 
 Die aktive Challenge (mindestens `nonce` und `ts`) MUSS nur bis zur Verifikation oder Regenerierung des QR-Codes lokal gehalten werden. Sie MUSS nicht dauerhaft persistiert werden. Bei App-Neustart ist der sichere Fallback, alte aktive Challenges zu verwerfen und einen neuen QR-Code zu erzeugen.
@@ -135,11 +135,13 @@ Eine eingehende Verification-Attestation DARF im Online-Ein-QR-Scan-Flow nur dan
 
 1. Die Signatur der Attestation ist gueltig.
 2. Die Attestation richtet sich an die lokale DID.
-3. Die Attestation-ID (`jti`) enthaelt eine lokal aktive, noch nicht verbrauchte Challenge-Nonce.
+3. Die Attestation-ID (`jti`) bindet exakt eine lokal aktive, noch nicht verbrauchte Challenge-Nonce gemaess der unten definierten `jti`-Grammatik.
 4. Die aktive Challenge ist zeitlich gueltig.
 5. Die Nonce wurde noch nicht in der Nonce-History konsumiert.
 
 Fehlt eine aktive Challenge-Nonce, MUSS die Attestation als ungebundene Remote-Verifikation behandelt werden. Sie DARF gespeichert oder dem User als separate Remote-Anfrage angezeigt werden, aber sie DARF NICHT als Beweis fuer eine physische Begegnung gelten. Damit wird verhindert, dass beliebige signierte Verification-Attestations als In-Person-Begegnung in den Trust Graph gelangen.
+
+Der Empfaenger MUSS die Nonce-Bindung ausschliesslich ueber einen Full-String-Match der `jti` pruefen. Unbeschraenkte Substring-Suche nach UUIDs ist ungueltig.
 
 ### Gegen-Verifikation und Pending-Counter-State (MUSS)
 
@@ -177,6 +179,8 @@ Empfänger MÜSSEN eine Liste bereits verwendeter Nonces führen um Replay-Angri
 - Nonce-Storage kann volatil sein (In-Memory reicht)
 - Bei Neustart: sicherer Fallback ist, alle Challenges der letzten 5 Minuten abzulehnen
 - Eine Nonce wird konsumiert sobald eine passende Attestation empfangen wird — sie kann nicht erneut verwendet werden
+- Die Nonce-History MUSS dieselbe normalisierte Nonce verwenden, die aus der `jti` extrahiert und mit der aktiven Challenge verglichen wurde.
+- Wenn eine spaetere Attestation eine gueltige `jti`-Grammatik hat und ihre normalisierte Nonce bereits in der Nonce-History steht, MUSS sie als `nonce-consumed` abgelehnt werden, auch wenn gerade keine aktive Challenge mit dieser Nonce existiert.
 
 ## Offline-Verifikation (Bidirektionaler QR-Scan)
 
@@ -235,14 +239,32 @@ Jede Partei erstellt eine Verification-Attestation für die andere — als JWS-s
   "iss": "did:key:z6Mk...bob",
   "sub": "did:key:z6Mk...alice",
   "nbf": 1776852000,
-  "jti": "urn:uuid:ver-<nonce>-<did-suffix>",
-  "inResponseTo": "urn:uuid:ver-<original-nonce>-<original-did-suffix>"
+  "jti": "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
 }
 ```
 
-Die `jti` (Attestation-ID) enthält die Nonce aus dem QR-Code, damit der Empfänger sie seiner aktiven Challenge zuordnen kann.
+Die `jti` (Attestation-ID) einer online nonce-gebundenen Verification-Attestation MUSS die Nonce aus dem QR-Code exakt in dieser Form binden:
 
-Bei einer Gegen-Verification enthält `jti` eine neue eindeutige ID der Gegen-Verification. Das optionale Feld `inResponseTo` MUSS gesetzt werden, wenn die Attestation als Gegen-Verification im Online-Ein-QR-Scan-Flow akzeptiert werden soll. `inResponseTo` referenziert die `jti` der urspruenglichen nonce-gebundenen Verification-Attestation.
+```abnf
+verification-jti = "urn:uuid:" uuid
+uuid = 8HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 12HEXDIG
+```
+
+Der `uuid`-Teil MUSS genau die QR-Challenge-Nonce sein. Implementierungen MUESSEN die `jti` gegen den gesamten String matchen, die UUID-Gruppe extrahieren und fuer Vergleich sowie Nonce-History auf Kleinbuchstaben normalisieren. UUID-Buchstaben `A-F` in der `jti` oder in der lokal aktiven Challenge sind deshalb gueltig, solange die normalisierten Werte exakt gleich sind.
+
+Fuer das Acceptance Gate gilt:
+
+| Eingehende `jti` | Ergebnis |
+|---|---|
+| `urn:uuid:<active-nonce>` mit beliebiger UUID-Gross-/Kleinschreibung | als nonce-gebundene In-Person-Verifikation akzeptierbar, wenn alle anderen Gates erfuellt sind |
+| `urn:uuid:<consumed-nonce>` | als `nonce-consumed` ablehnen |
+| `urn:uuid:<uuid>`, aber UUID ist weder aktive noch konsumierte Nonce | als ungebundene Remote-Verifikation behandeln |
+| `jti` mit mehreren UUID-foermigen Tokens | als ungebundene Remote-Verifikation behandeln |
+| `jti` mit zusaetzlichem Prefix/Suffix, falschem URN-Namespace oder ungueltigen Trennzeichen | als ungebundene Remote-Verifikation behandeln |
+
+Eine `jti` wie `urn:uuid:ver-<nonce>-<did-suffix>` ist fuer Trust 002 nonce-gebundene Verification-Attestations ungueltig, weil sie weder eine gueltige UUID-URN noch eine eindeutige Nonce-Bindung ist.
+
+Bei einer Gegen-Verification enthält `jti` eine neue eindeutige ID der Gegen-Verification, z.B. `urn:uuid:123e4567-e89b-12d3-a456-426614174000`. Das optionale Feld `inResponseTo` MUSS gesetzt werden, wenn die Attestation als Gegen-Verification im Online-Ein-QR-Scan-Flow akzeptiert werden soll. `inResponseTo` referenziert die `jti` der urspruenglichen nonce-gebundenen Verification-Attestation, z.B. `urn:uuid:550e8400-e29b-41d4-a716-446655440000`.
 
 Die Verification-Attestation sagt: **"Ich habe diese Person getroffen und ihre Identität verifiziert."** Sie wird wie jede andere Attestation behandelt — der Empfänger besitzt sie und entscheidet ob er sie akzeptiert und zeigt (Empfängerprinzip, siehe [Trust 001](001-attestations.md)).
 

--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -32,7 +32,7 @@
       "test_vectors": [
         {
           "file": "test-vectors/phase-1-interop.json",
-          "sections": ["attestation_vc_jws"]
+          "sections": ["attestation_vc_jws", "trust002_jti_nonce_binding"]
         }
       ]
     },

--- a/scripts/validate_test_vectors.py
+++ b/scripts/validate_test_vectors.py
@@ -16,6 +16,9 @@ ROOT = Path(__file__).resolve().parents[1]
 VECTOR = ROOT / "test-vectors" / "phase-1-interop.json"
 DEVICE_VECTOR = ROOT / "test-vectors" / "device-delegation.json"
 B58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+TRUST002_JTI_RE = re.compile(
+    r"^urn:uuid:([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+)
 
 
 def b64u_decode(value: str) -> bytes:
@@ -212,6 +215,30 @@ def verify_broker_registration_control_frames(vector: dict, identity: dict) -> N
     }
 
 
+def classify_trust002_jti(jti: str, active_nonce: str, consumed_nonces: set[str]) -> tuple[str | None, str]:
+    match = TRUST002_JTI_RE.fullmatch(jti)
+    if not match:
+        return None, "unbound-remote"
+
+    nonce = match.group(1).lower()
+    if nonce in consumed_nonces:
+        return nonce, "nonce-consumed"
+    if nonce == active_nonce.lower():
+        return nonce, "accept-in-person"
+    return nonce, "unbound-remote"
+
+
+def verify_trust002_jti_nonce_binding(vector: dict) -> None:
+    active_nonce = vector["activeNonce"]
+    assert vector["activeNonceUppercase"].lower() == active_nonce
+    consumed_nonces = {nonce.lower() for nonce in vector["consumedNonces"]}
+
+    for case in vector["cases"]:
+        extracted_nonce, disposition = classify_trust002_jti(case["jti"], active_nonce, consumed_nonces)
+        assert extracted_nonce == case["extractedNonce"], case["name"]
+        assert disposition == case["expectedDisposition"], case["name"]
+
+
 def iso_to_unix(value: str) -> int:
     from datetime import datetime
 
@@ -326,6 +353,9 @@ def main() -> None:
 
     verify_broker_registration_control_frames(data["broker_registration_control_frames"], identity)
     print("broker registration control frames ok")
+
+    verify_trust002_jti_nonce_binding(data["trust002_jti_nonce_binding"])
+    print("trust002 jti nonce binding ok")
 
     cap = data["space_capability_jws"]
     cap_pub = bytes.fromhex(cap["verification_key_hex"])

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -240,8 +240,9 @@ Eine konforme Implementierung MUSS fuer die jeweils beanspruchten Profile:
 3. Den AES-256-GCM Ciphertext mit dem gegebenen Key und Nonce entschluesseln koennen.
 4. Fuer alle JCS-Test-Vektoren dieselben SHA-256 Hashes erzeugen.
 5. Den Attestation-VC-JWS aus den Phase-1-Interop-Vektoren verifizieren koennen.
-6. Die Phase-1-Interop-Vektoren in [`phase-1-interop.md`](phase-1-interop.md) reproduzieren koennen.
-7. Fuer `wot-device-delegation@0.1`: die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
+6. Fuer `wot-trust@0.1`: die Trust-002-`jti`-Nonce-Binding-Faelle aus `phase-1-interop.json` reproduzieren koennen.
+7. Die Phase-1-Interop-Vektoren in [`phase-1-interop.md`](phase-1-interop.md) reproduzieren koennen.
+8. Fuer `wot-device-delegation@0.1`: die Device-Delegation-Vektoren in [`device-delegation.json`](device-delegation.json) verifizieren und die Negativfaelle ablehnen koennen.
 
 Wenn diese Tests bestehen, ist die kryptographische Basis interoperabel.
 
@@ -251,6 +252,7 @@ Die folgenden Vektoren sind in [`phase-1-interop.md`](phase-1-interop.md) dokume
 
 - **WoT Plaintext Envelope** - DIDComm-v2-kompatibler Envelope, validiert mit etablierten DIDComm-v2-Libraries.
 - **Attestation VC-JWS** - W3C VC 2.0 Payload mit `typ: "vc+jwt"` und `kid`.
+- **Trust 002 `jti` Nonce Binding** - Full-String-`urn:uuid:<uuid>`-Grammatik, UUID-Kleinschreibungsnormalisierung, Replay- und Unbound-Klassifikation.
 - **ECIES** - X25519 ECDH + HKDF + AES-256-GCM (Peer-to-Peer-Verschluesselung).
 - **Space Content Key** - Deterministische Nonce aus `(deviceId, seq)`, Verschluesselung/Entschluesselung.
 - **Broker Control-Frame Registrierung** - `register`/`challenge`/`challenge-response`/`registered`-Handshake mit JCS-Transcript und Ed25519-Signatur.

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -193,6 +193,56 @@
     "signature_b64": "semxZPGYdkExNWs5vWh76XaqlPvZsCE3sZLxFOQMg1J4oALgf2QV8rPv2Q6bMCIygzcmEWKolJG3eRJxZdOBAA",
     "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoidmMrand0In0.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3dlYi1vZi10cnVzdC5kZS92b2NhYi92MSJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJjbGFpbSI6Imthbm4gZ3V0IHByb2dyYW1taWVyZW4iLCJpZCI6ImRpZDprZXk6ejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIn0sImlzcyI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwiaXNzdWVyIjoiZGlkOmtleTp6Nk1rbzNaRWpLSldRQU01bkRYS29aOWpFcnZ2eGJXYllnUzhLSlhZcEM1SGJ1OGEiLCJuYmYiOjE3NzY3NjU2MDAsInN1YiI6ImRpZDprZXk6ejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIldvdEF0dGVzdGF0aW9uIl0sInZhbGlkRnJvbSI6IjIwMjYtMDQtMjFUMTA6MDA6MDBaIn0.semxZPGYdkExNWs5vWh76XaqlPvZsCE3sZLxFOQMg1J4oALgf2QV8rPv2Q6bMCIygzcmEWKolJG3eRJxZdOBAA"
   },
+  "trust002_jti_nonce_binding": {
+    "notes": "Trust 002 online Verification-Attestation jti nonce grammar. Receivers full-match `urn:uuid:<uuid>`, normalize the UUID to lowercase, compare against the active challenge nonce, and use the same normalized value for nonce-history replay protection.",
+    "activeNonce": "550e8400-e29b-41d4-a716-446655440000",
+    "activeNonceUppercase": "550E8400-E29B-41D4-A716-446655440000",
+    "consumedNonces": ["7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"],
+    "cases": [
+      {
+        "name": "valid-active-nonce-bound-jti",
+        "jti": "urn:uuid:550e8400-e29b-41d4-a716-446655440000",
+        "extractedNonce": "550e8400-e29b-41d4-a716-446655440000",
+        "expectedDisposition": "accept-in-person"
+      },
+      {
+        "name": "uppercase-uuid-normalizes-to-active-nonce",
+        "jti": "urn:uuid:550E8400-E29B-41D4-A716-446655440000",
+        "extractedNonce": "550e8400-e29b-41d4-a716-446655440000",
+        "expectedDisposition": "accept-in-person"
+      },
+      {
+        "name": "malformed-ver-prefix-pseudo-urn-is-unbound",
+        "jti": "urn:uuid:ver-550e8400-e29b-41d4-a716-446655440000-did-suffix",
+        "extractedNonce": null,
+        "expectedDisposition": "unbound-remote"
+      },
+      {
+        "name": "wrong-delimiters-are-unbound",
+        "jti": "urn:uuid:550e8400_e29b_41d4_a716_446655440000",
+        "extractedNonce": null,
+        "expectedDisposition": "unbound-remote"
+      },
+      {
+        "name": "nonmatching-valid-uuid-is-unbound",
+        "jti": "urn:uuid:123e4567-e89b-12d3-a456-426614174000",
+        "extractedNonce": "123e4567-e89b-12d3-a456-426614174000",
+        "expectedDisposition": "unbound-remote"
+      },
+      {
+        "name": "consumed-nonce-replay-is-rejected",
+        "jti": "urn:uuid:7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+        "extractedNonce": "7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+        "expectedDisposition": "nonce-consumed"
+      },
+      {
+        "name": "multi-uuid-jti-is-ambiguous-unbound",
+        "jti": "urn:uuid:550e8400-e29b-41d4-a716-446655440000:7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b",
+        "extractedNonce": null,
+        "expectedDisposition": "unbound-remote"
+      }
+    ]
+  },
   "ecies": {
     "recipient_x25519_public_b64": "yFB4c_1SqTGolVBTKhCBJShSWf-NzXr4XCyDF3FKeUQ",
     "ephemeral_private_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",


### PR DESCRIPTION
## Task

- Clarify Trust 002 Verification-Attestation jti nonce grammar
- Generated by the local autonomous runner.
- This PR is a draft until a human decides otherwise.
- The runner must not merge this PR.
- Task kind: spec

## Spec Refs

- https://github.com/real-life-org/wot-spec/issues/47
- 02-wot-trust/002-verifikation.md#acceptance-gate-fuer-online-verifikation-muss
- 02-wot-trust/002-verifikation.md#nonce-history-muss
- 02-wot-trust/002-verifikation.md#verification-attestation
- 02-wot-trust/001-attestations.md
- schemas/qr-challenge.schema.json
- schemas/attestation-vc-payload.schema.json
- test-vectors/phase-1-interop.json
- conformance/manifest.json
- scripts/validate_test_vectors.py
- test-vectors/README.md

## Acceptance

- Resolve wot-spec#47 by normatively specifying the exact `jti` shape that implementations MUST create for online Trust 002 nonce-bound Verification-Attestations.
- Replace the ambiguous wording that `jti` merely 'contains' the nonce with a precise matching rule. The rule MUST avoid unrestricted substring matching and MUST be interoperable for active challenge acceptance.
- Specify how receivers extract or compare the challenge nonce from `jti` for the active challenge acceptance gate, including case normalization expectations for UUIDs.
- Specify how nonce-history replay protection uses the same normalized nonce after the active challenge has been consumed or reset.
- Clarify whether `jti` values that contain multiple UUID-shaped tokens, a nonce with invalid delimiters, uppercase UUID text, or a UUID that is not the active/consumed nonce are accepted, rejected as `nonce-consumed`, or classified as unbound remote verification.
- Update the Verification-Attestation example so the `jti` and `inResponseTo` examples are syntactically valid under the clarified grammar and no longer rely on an invalid `urn:uuid:ver-...` pseudo-URN if that shape is not valid.
- Add or update deterministic Trust 002 test-vector material for valid nonce-bound `jti`, uppercase-normalized nonce matching, malformed/nonmatching `jti`, consumed nonce replay classification, and multi-UUID ambiguity if the chosen grammar needs it.
- If a vector section is added, update `scripts/validate_test_vectors.py`, `conformance/manifest.json`, and `test-vectors/README.md` so the new Trust 002 `jti` grammar examples are discoverable and validated.
- Keep the PR small, reviewable, and spec-only.

## Setup Commands

- printf 'node_modules\n' > /tmp/wot-spec-runner-exclude && git config core.excludesFile /tmp/wot-spec-runner-exclude && test -e node_modules || ln -s /home/fritz/workspace/workspace/wot-spec/node_modules node_modules

## Checks

- npm run validate
- python3 scripts/validate_test_vectors.py
- python3 scripts/validate_spec_consistency.py
- git diff --check

## Persistent Context Refs

- CONFORMANCE.md
- docs/automation/spec-change-checklist.md
- docs/automation/spec-agent-flow.md
- package.json
- .github/workflows/validate.yml

## TDD

- No task-specific TDD metadata provided; behavior-changing work should still follow repository TDD rules.

## Human Gates

- Do not implement TypeScript behavior in this spec task.
- Do not change Trust 001 generic Attestation semantics except as needed to clarify Trust 002 Verification-Attestation `jti` usage.
- Do not redefine QR challenge nonce syntax outside Trust 002 unless the existing QR schema is internally inconsistent.
- Do not decide unrelated delivery, storage, contact update, publication, or attestation-ack behavior.
- If the current illustrative `urn:uuid:ver-<nonce>-<did-suffix>` shape cannot be reconciled with a valid URI/URN grammar without a normative breaking change, stop at human gate and explain the tradeoff.
- Do not push to `main` or any default branch.

## Residual Risk

- Dynamic run status, check results, review findings, and audit artifact paths are reported in the Agent Runner Summary comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Tightened Trust 002 verification text: stricter nonce-binding semantics, formal JTI/UUID grammar, lowercase UUID normalization, explicit handling for active/consumed/malformed/multi-token outcomes; updated test-vectors guidance.

* **Tests**
  * Added deterministic nonce-binding test vectors covering valid binding, uppercase normalization, malformed/unbound JTIs, non-matching UUIDs, replayed consumed nonces, and ambiguous multi-UUID cases.

* **Validation**
  * Enhanced test validation to parse/classify JTI values and assert expected nonce-binding dispositions.

* **Chores**
  * Updated test manifest to include the new nonce-binding test section.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/real-life-org/wot-spec/pull/62)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->