### PR TITLE
Clarify Trust 002 verification-jti prefix case sensitivity

### DIFF
--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -248,11 +248,11 @@ Jede Partei erstellt eine Verification-Attestation für die andere — als JWS-s
 Die `jti` (Attestation-ID) einer online nonce-gebundenen Verification-Attestation MUSS die Nonce aus dem QR-Code exakt in dieser Form binden:
 
 ```abnf
-verification-jti = "urn:uuid:" uuid
+verification-jti = %s"urn:uuid:" uuid
 uuid = 8HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 4HEXDIG "-" 12HEXDIG
 ```
 
-Der `uuid`-Teil MUSS genau die QR-Challenge-Nonce sein. Implementierungen MUESSEN die `jti` gegen den gesamten String matchen, die UUID-Gruppe extrahieren und fuer Vergleich sowie Nonce-History auf Kleinbuchstaben normalisieren. UUID-Buchstaben `A-F` in der `jti` sind deshalb gueltig, solange der normalisierte Wert exakt der lokal aktiven Challenge-Nonce entspricht.
+Der Literal-Prefix `urn:uuid:` in `verification-jti` ist case-sensitiv und MUSS exakt lowercase geschrieben sein. Das ABNF verwendet deshalb den case-sensitiven Literal-Marker `%s`; Implementierungen DUERFEN nicht die standardmaessige case-insensitive ABNF-Literal-Semantik auf den Prefix anwenden. Der `uuid`-Teil MUSS genau die QR-Challenge-Nonce sein. Implementierungen MUESSEN die `jti` gegen den gesamten String matchen, die UUID-Gruppe extrahieren und fuer Vergleich sowie Nonce-History auf Kleinbuchstaben normalisieren. UUID-Buchstaben `A-F` in der `jti` sind deshalb gueltig, solange der normalisierte Wert exakt der lokal aktiven Challenge-Nonce entspricht.
 
 Fuer das Acceptance Gate gilt:
 
@@ -261,6 +261,7 @@ Fuer das Acceptance Gate gilt:
 | `urn:uuid:<active-nonce>` mit beliebiger UUID-Gross-/Kleinschreibung | als nonce-gebundene In-Person-Verifikation akzeptierbar, wenn alle anderen Gates erfuellt sind |
 | `urn:uuid:<consumed-nonce>` | als `nonce-consumed` ablehnen |
 | `urn:uuid:<uuid>`, aber UUID ist weder aktive noch konsumierte Nonce | als ungebundene Remote-Verifikation behandeln |
+| `URN:UUID:<uuid>` oder `Urn:Uuid:<uuid>` mit uppercase oder mixed-case Prefix | als ungebundene Remote-Verifikation behandeln; nicht als In-Person-Beweis akzeptieren und nicht als `nonce-consumed` ablehnen |
 | `jti` mit mehreren UUID-foermigen Tokens | als ungebundene Remote-Verifikation behandeln |
 | `jti` mit zusaetzlichem Prefix/Suffix, falschem URN-Namespace oder ungueltigen Trennzeichen | als ungebundene Remote-Verifikation behandeln |
 

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -253,7 +253,7 @@ Die folgenden Vektoren sind in [`phase-1-interop.md`](phase-1-interop.md) dokume
 
 - **WoT Plaintext Envelope** - DIDComm-v2-kompatibler Envelope, validiert mit etablierten DIDComm-v2-Libraries.
 - **Attestation VC-JWS** - W3C VC 2.0 Payload mit `typ: "vc+jwt"` und `kid`.
-- **Trust 002 `jti` Nonce Binding** - Full-String-`urn:uuid:<uuid>`-Grammatik, UUID-Kleinschreibungsnormalisierung, Replay- und Unbound-Klassifikation.
+- **Trust 002 `jti` Nonce Binding** - Full-String-`urn:uuid:<uuid>`-Grammatik mit lowercase Prefix-Match, UUID-Kleinschreibungsnormalisierung, Replay- und Unbound-Klassifikation.
 - **ECIES** - X25519 ECDH + HKDF + AES-256-GCM (Peer-to-Peer-Verschluesselung).
 - **Space Content Key** - Deterministische Nonce aus `(deviceId, seq)`, Verschluesselung/Entschluesselung.
 - **Broker Control-Frame Registrierung** - `register`/`challenge`/`challenge-response`/`registered`-Handshake mit JCS-Transcript und Ed25519-Signatur.

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -238,7 +238,7 @@
     "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoidmMrand0In0.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3dlYi1vZi10cnVzdC5kZS92b2NhYi92MSJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJjbGFpbSI6Imthbm4gZ3V0IHByb2dyYW1taWVyZW4iLCJpZCI6ImRpZDprZXk6ejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIn0sImlzcyI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhIiwiaXNzdWVyIjoiZGlkOmtleTp6Nk1rbzNaRWpLSldRQU01bkRYS29aOWpFcnZ2eGJXYllnUzhLSlhZcEM1SGJ1OGEiLCJuYmYiOjE3NzY3NjU2MDAsInN1YiI6ImRpZDprZXk6ejZNa3BUSFI4Vk5zQnhZQUFXSHV0MkdlYWRkOWpTd3VCVjh4Um9BbndXc2R2a3RIIiwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIldvdEF0dGVzdGF0aW9uIl0sInZhbGlkRnJvbSI6IjIwMjYtMDQtMjFUMTA6MDA6MDBaIn0.semxZPGYdkExNWs5vWh76XaqlPvZsCE3sZLxFOQMg1J4oALgf2QV8rPv2Q6bMCIygzcmEWKolJG3eRJxZdOBAA"
   },
   "trust002_jti_nonce_binding": {
-    "notes": "Trust 002 online Verification-Attestation jti nonce grammar. Receivers full-match `urn:uuid:<uuid>`, normalize the UUID to lowercase, compare against the active challenge nonce, and use the same normalized value for nonce-history replay protection.",
+    "notes": "Trust 002 online Verification-Attestation jti nonce grammar. Receivers full-match the lowercase literal prefix `urn:uuid:<uuid>`, normalize the UUID portion to lowercase, compare against the active challenge nonce, and use the same normalized value for nonce-history replay protection. Uppercase or mixed-case `URN:UUID:` / `Urn:Uuid:` prefixes are unbound remote verifications, not nonce-bound Trust 002 `verification-jti` values.",
     "activeNonce": "550e8400-e29b-41d4-a716-446655440000",
     "activeNonceUppercase": "550E8400-E29B-41D4-A716-446655440000",
     "consumedNonces": ["7f3a2b10-4c5d-4e6f-8a7b-9c0d1e2f3a4b"],
@@ -254,6 +254,18 @@
         "jti": "urn:uuid:550E8400-E29B-41D4-A716-446655440000",
         "extractedNonce": "550e8400-e29b-41d4-a716-446655440000",
         "expectedDisposition": "accept-in-person"
+      },
+      {
+        "name": "uppercase-prefix-is-unbound-remote",
+        "jti": "URN:UUID:550e8400-e29b-41d4-a716-446655440000",
+        "extractedNonce": null,
+        "expectedDisposition": "unbound-remote"
+      },
+      {
+        "name": "mixed-case-prefix-is-unbound-remote",
+        "jti": "Urn:Uuid:550e8400-e29b-41d4-a716-446655440000",
+        "extractedNonce": null,
+        "expectedDisposition": "unbound-remote"
       },
       {
         "name": "malformed-ver-prefix-pseudo-urn-is-unbound",


### PR DESCRIPTION
## Task

- Clarify Trust 002 verification-jti prefix case sensitivity
- Generated by the local autonomous runner.
- This PR is a draft until a human decides otherwise.
- The runner must not merge this PR.
- Task kind: spec

Closes #63.

## Spec Refs

- https://github.com/real-life-org/wot-spec/issues/63
- 02-wot-trust/002-verifikation.md#verification-attestation
- 02-wot-trust/002-verifikation.md#acceptance-gate-fuer-online-verifikation-muss
- 02-wot-trust/002-verifikation.md#nonce-history-muss
- test-vectors/phase-1-interop.json
- test-vectors/README.md
- conformance/manifest.json

## Acceptance

- Resolve wot-spec#63 by normatively specifying whether the Trust 002 `verification-jti` literal prefix is case-sensitive.
- Choose the conservative canonical rule unless there is an explicit contrary requirement in the current spec: receivers MUST full-match the lowercase literal `urn:uuid:` prefix, while UUID hex letters A-F remain valid only inside the UUID portion and are normalized for comparison.
- State that uppercase or mixed-case `URN:UUID:` / `Urn:Uuid:` prefixes are not Trust 002 nonce-bound `verification-jti` values and MUST be classified as unbound remote verifications, not accepted as in-person proof and not rejected as consumed nonce replay.
- Keep the ABNF and prose aligned so implementers do not rely on ABNF's default case-insensitive literal behavior for the `urn:uuid:` prefix.
- Add deterministic `trust002_jti_nonce_binding` vector cases for uppercase and mixed-case prefixes with `extractedNonce: null` and `expectedDisposition: unbound-remote`.
- Keep existing vector behavior for uppercase UUID hex after the lowercase prefix: it remains accepted after UUID normalization when it matches the active challenge nonce.
- Update `test-vectors/README.md` only where needed so the documented Trust 002 `jti` vector summary mentions lowercase-prefix canonical matching.
- Keep the PR small, reviewable, and spec-only.
- Reference and close wot-spec#63 in the PR body when the decision is implemented.

## Setup Commands

- printf 'node_modules\n' > /tmp/wot-spec-runner-exclude && git config core.excludesFile /tmp/wot-spec-runner-exclude && test -e node_modules || ln -s /home/fritz/workspace/workspace/wot-spec/node_modules node_modules

## Checks

- npm run validate
- python3 scripts/validate_test_vectors.py
- python3 scripts/validate_spec_consistency.py
- git diff --check

## Persistent Context Refs

- CONFORMANCE.md
- docs/automation/spec-change-checklist.md
- docs/automation/spec-agent-flow.md
- package.json
- .github/workflows/validate.yml
- ../web-of-trust/packages/wot-core/src/protocol/trust/qr-challenge.ts
- ../web-of-trust/packages/wot-core/tests/TrustJtiNonceBinding.test.ts
- ../web-of-trust/packages/wot-core/tests/fixtures/wot-spec/phase-1-interop.json

## TDD

- No task-specific TDD metadata provided; behavior-changing work should still follow repository TDD rules.

## Human Gates

- Do not implement TypeScript behavior in this spec task.
- Do not reopen the already merged Trust 002 full-string `jti` grammar decision from PR #62 except to clarify the case sensitivity of the literal `urn:uuid:` prefix.
- Do not change QR challenge nonce canonical UUID-v4 syntax from PR #65.
- Do not change Trust 001 generic Attestation `jti` semantics outside the Trust 002 online Verification-Attestation nonce-binding subsection.
- Do not decide delivery, storage, contact update, publication, attestation-ack, nonce-history retention duration, or counter-verification workflow behavior.
- If the prefix-case decision requires accepting RFC 8141 case-insensitive URN aliases contrary to the current vectors and reference implementation, stop at human gate and explain the interop tradeoff instead of broadening behavior.
- Do not push to `main` or any default branch.

## Residual Risk

- Dynamic run status, check results, review findings, and audit artifact paths are reported in the Agent Runner Summary comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified verification spec for JTI nonce binding: require exact lowercase "urn:uuid:" prefix and full-string matching
  * Specified UUID lowercase normalization for comparisons and nonce-history checks
  * Added explicit classification rules and new test cases for uppercase/mixed-case prefix variants (treated as unbound remote)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/real-life-org/wot-spec/pull/66)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->