### PR TITLE
spec(trust-002,sync-004): WotVerification type marker + disjunkter /v÷/a-Split (#100, refs #34)

### DIFF
--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -104,7 +104,7 @@ Im Normalfall sind beide Parteien mit einem Broker verbunden. Ein einziger QR-Sc
    → Signatur verifizieren
    → `inResponseTo` matcht Bobs lokalen Pending-Counter-State
    → Pending-Counter-State ist noch nicht abgelaufen
-   → Gegenseitige In-Person-Verifikation abgeschlossen
+   → Gegenseitige Live-Verifikation abgeschlossen
 ```
 
 ### Warum die Nonce entscheidend ist
@@ -133,7 +133,7 @@ Die aktive Challenge (mindestens `nonce` und `ts`) MUSS nur bis zur Verifikation
 
 ### Acceptance Gate fuer Online-Verifikation (MUSS)
 
-Eine eingehende Verification-Attestation DARF im Online-Ein-QR-Scan-Flow nur dann als In-Person-Verifikation akzeptiert oder automatisch zur Gegen-Verifikation angeboten werden, wenn alle Bedingungen erfuellt sind:
+Eine eingehende Verification-Attestation DARF im Online-Ein-QR-Scan-Flow nur dann als Live-Verifikation akzeptiert oder automatisch zur Gegen-Verifikation angeboten werden, wenn alle Bedingungen erfuellt sind:
 
 1. Die Signatur der Attestation ist gueltig.
 2. Die Attestation richtet sich an die lokale DID.
@@ -141,7 +141,7 @@ Eine eingehende Verification-Attestation DARF im Online-Ein-QR-Scan-Flow nur dan
 4. Die aktive Challenge ist zeitlich gueltig.
 5. Die Nonce wurde noch nicht in der Nonce-History konsumiert.
 
-Fehlt eine aktive Challenge-Nonce, MUSS die Attestation als ungebundene Remote-Verifikation behandelt werden. Sie DARF gespeichert oder dem User als separate Remote-Anfrage angezeigt werden, aber sie DARF NICHT als Beweis fuer eine physische Begegnung gelten. Damit wird verhindert, dass beliebige signierte Verification-Attestations als In-Person-Begegnung in den Trust Graph gelangen.
+Fehlt eine aktive Challenge-Nonce, MUSS die Attestation als ungebundene (nicht-live) Verifikation behandelt werden. Sie DARF gespeichert oder dem User als separate Anfrage angezeigt werden, aber sie DARF NICHT als Live-Verifikation gelten (keine frische Challenge-Response, also kein Beweis einer Live-Interaktion). Damit wird verhindert, dass beliebige signierte Verification-Attestations als Live-Verifikation in den Trust Graph gelangen.
 
 Der Empfaenger MUSS die Nonce-Bindung ausschliesslich ueber einen Full-String-Match der `jti` pruefen. Unbeschraenkte Substring-Suche nach UUIDs ist ungueltig.
 
@@ -149,7 +149,7 @@ Der Empfaenger MUSS die Nonce-Bindung ausschliesslich ueber einen Full-String-Ma
 
 Der Online-Ein-QR-Scan-Flow benoetigt keinen zweiten QR-Scan. Der zweite QR-Scan wuerde nur erneut kopierbare QR-Daten uebertragen; die Sicherheitsbindung entsteht durch die frische Challenge-Nonce, die Signatur, den lokalen Pending-State und die bewusste Bestaetigung durch den User.
 
-Damit zwei beliebige Verification-Attestations nicht automatisch eine gegenseitige In-Person-Verifikation ergeben, MUESSEN Implementierungen Gegen-Verifikationen an lokalen State binden:
+Damit zwei beliebige Verification-Attestations nicht automatisch eine gegenseitige Live-Verifikation ergeben, MUESSEN Implementierungen Gegen-Verifikationen an lokalen State binden:
 
 1. Wenn Bob nach dem Scan von Alices QR-Code eine Verification-Attestation an Alice erstellt, MUSS Bob lokal einen `pendingCounterVerification`-Eintrag speichern.
 2. Dieser Eintrag MUSS mindestens enthalten:
@@ -157,17 +157,17 @@ Damit zwei beliebige Verification-Attestations nicht automatisch eine gegenseiti
    - `originalVerificationId`: die `jti` von Bobs Verification-Attestation
    - `createdAt`: Erstellungszeitpunkt
    - `expiresAt`: Ablaufzeitpunkt des Pending-Counter-Fensters
-3. Das Pending-Counter-Fenster DARF hoechstens 24 Stunden betragen. Nach Ablauf MUSS eine eingehende Gegen-Verification als ungebundene Remote-Verifikation behandelt werden oder einen neuen QR-Flow erfordern.
+3. Das Pending-Counter-Fenster DARF hoechstens 24 Stunden betragen. Nach Ablauf MUSS eine eingehende Gegen-Verification als ungebundene (nicht-live) Verifikation behandelt werden oder einen neuen QR-Flow erfordern.
 4. Wenn Alice Bobs nonce-gebundene Verification-Attestation akzeptiert und Bob bestaetigt, MUSS Alices Gegen-Verification-Attestation ein Top-Level-Feld `inResponseTo` enthalten. Der Wert MUSS exakt der `jti` von Bobs urspruenglicher Verification-Attestation entsprechen.
-5. Wenn Bob Alices Gegen-Verification empfaengt, DARF er sie nur dann als Abschluss einer gegenseitigen In-Person-Verifikation akzeptieren, wenn alle Bedingungen erfuellt sind:
+5. Wenn Bob Alices Gegen-Verification empfaengt, DARF er sie nur dann als Abschluss einer gegenseitigen Live-Verifikation akzeptieren, wenn alle Bedingungen erfuellt sind:
    - Die Signatur der Gegen-Verification ist gueltig.
    - Die Gegen-Verification richtet sich an Bobs lokale DID.
    - `issuer`/`iss` der Gegen-Verification entspricht `counterpartyDid` im Pending-Counter-State.
    - `inResponseTo` entspricht `originalVerificationId`.
    - Der Pending-Counter-State ist noch nicht abgelaufen.
-6. Fehlt `inResponseTo`, fehlt der passende Pending-Counter-State oder ist der Pending-Counter-State abgelaufen, DARF die Gegen-Verification NICHT als In-Person-Mutual-Verifikation zaehlen. Sie DARF als ungebundene Remote-Verifikation gespeichert oder angezeigt werden.
+6. Fehlt `inResponseTo`, fehlt der passende Pending-Counter-State oder ist der Pending-Counter-State abgelaufen, DARF die Gegen-Verification NICHT als gegenseitige Live-Verifikation zaehlen. Sie DARF als ungebundene (nicht-live) Verifikation gespeichert oder angezeigt werden.
 
-Eine Implementierung DARF den Pending-Counter-State kuerzer halten oder den User jederzeit einen neuen QR-Flow starten lassen. Sie DARF ihn jedoch NICHT unbegrenzt als In-Person-Beweis verwenden.
+Eine Implementierung DARF den Pending-Counter-State kuerzer halten oder den User jederzeit einen neuen QR-Flow starten lassen. Sie DARF ihn jedoch NICHT unbegrenzt als Live-Beweis verwenden.
 
 Hinweis zur Validierbarkeit: JSON-Schema kann nur die Feldform von `inResponseTo` validieren. Die Existenz und Integritaet des lokalen `pendingCounterVerification`-Eintrags, `inResponseTo`-Exact-Match, `issuer`/`iss`-Bindung an `counterpartyDid`, lokale DID-Bindung und `expiresAt`-Ablaufpruefung sind zustands- und zeitabhaengig. Sie MUESSEN durch Laufzeitlogik und Conformance-Tests mit kontrolliertem lokalen State und kontrollierter Uhr geprueft werden.
 
@@ -245,7 +245,11 @@ Jede Partei erstellt eine Verification-Attestation für die andere — als JWS-s
 }
 ```
 
-Eine Verification-Attestation ist eine `WotAttestation` mit dem zusätzlichen `type`-Eintrag `WotVerification`. Dieser `type`-Eintrag ist der normative Diskriminator einer In-Person-Verifikation. Alle Attestation-Regeln aus [Trust 001](001-attestations.md) gelten unverändert, da das `type`-Array weiterhin `WotAttestation` enthält. Der `credentialSubject.claim`-Text (z.B. `"in-person verifiziert"`) ist ein menschenlesbares, frei lokalisierbares Label und DARF NICHT als Typ-Diskriminator verwendet werden. Clients und Broker MÜSSEN Verification-Attestations über den `WotVerification`-`type`-Eintrag erkennen, nicht über den `claim`-Wert.
+Eine **Live-Verifikation** ist eine nonce-gebundene Verifikation: ihre `jti` bindet eine frische Challenge-Nonce gemäß Acceptance Gate und beweist damit eine **frische Live-Interaktion zu einem Zeitpunkt** — nicht physische Präsenz. (Physische Anwesenheit ist die intendierte Nutzung der QR-Zeremonie, aber kein kryptographischer Beweis.)
+
+Eine Live-Verifikation wird als `WotAttestation` mit dem zusätzlichen `type`-Eintrag `WotVerification` ausgestellt. Dieser `type`-Eintrag ist der **normative Diskriminator** einer Live-Verifikation. Alle Attestation-Regeln aus [Trust 001](001-attestations.md) gelten unverändert, da das `type`-Array weiterhin `WotAttestation` enthält. Der `credentialSubject.claim`-Text (z.B. `"in-person verifiziert"`) ist ein menschenlesbares, frei lokalisierbares Label und DARF NICHT als Diskriminator verwendet werden. Clients und Broker MÜSSEN Live-Verifikationen über den `WotVerification`-`type`-Eintrag erkennen, nicht über den `claim`-Wert.
+
+Eine **ungebundene (nicht-live) Verifikation** — ohne frische Challenge-Nonce, z.B. eine Empfehlung ohne Live-Austausch (siehe [Verifikation ohne physisches Treffen](#verifikation-ohne-physisches-treffen)) — trägt `WotVerification` **NICHT** und ist eine gewöhnliche `WotAttestation`.
 
 Die `jti` (Attestation-ID) einer online nonce-gebundenen Verification-Attestation MUSS die Nonce aus dem QR-Code exakt in dieser Form binden:
 
@@ -260,10 +264,10 @@ Fuer das Acceptance Gate gilt:
 
 | Eingehende `jti` | Ergebnis |
 |---|---|
-| `urn:uuid:<active-nonce>` mit beliebiger UUID-Gross-/Kleinschreibung | als nonce-gebundene In-Person-Verifikation akzeptierbar, wenn alle anderen Gates erfuellt sind |
+| `urn:uuid:<active-nonce>` mit beliebiger UUID-Gross-/Kleinschreibung | als nonce-gebundene Live-Verifikation akzeptierbar, wenn alle anderen Gates erfuellt sind |
 | `urn:uuid:<consumed-nonce>` | als `nonce-consumed` ablehnen |
 | `urn:uuid:<uuid>`, aber UUID ist weder aktive noch konsumierte Nonce | als ungebundene Remote-Verifikation behandeln |
-| `URN:UUID:<uuid>` oder `Urn:Uuid:<uuid>` mit uppercase oder mixed-case Prefix | als ungebundene Remote-Verifikation behandeln; nicht als In-Person-Beweis akzeptieren und nicht als `nonce-consumed` ablehnen |
+| `URN:UUID:<uuid>` oder `Urn:Uuid:<uuid>` mit uppercase oder mixed-case Prefix | als ungebundene (nicht-live) Verifikation behandeln; nicht als Live-Verifikation akzeptieren und nicht als `nonce-consumed` ablehnen |
 | `jti` mit mehreren UUID-foermigen Tokens | als ungebundene Remote-Verifikation behandeln |
 | `jti` mit zusaetzlichem Prefix/Suffix, falschem URN-Namespace oder ungueltigen Trennzeichen | als ungebundene Remote-Verifikation behandeln |
 
@@ -299,4 +303,4 @@ Für Fälle wo kein Treffen möglich ist (z.B. Empfehlung durch einen gemeinsame
 3. Alice ruft Bobs Profil ab (inkl. Encryption Key) und erstellt eine Verification-Attestation
 4. Bob empfängt sie und kann gegenverifizieren (`counterVerify`)
 
-Die Verifikation ist schwächer als bei einem physischen Treffen — sie beweist nur die Empfehlung durch einen gemeinsamen Kontakt, nicht die physische Identität. Ob eine Verification-Attestation nonce-gebunden (In-Person) oder ungebunden (Remote) ist, entscheidet die nonce-gebundene `jti` gemäß Acceptance Gate (siehe oben), NICHT der `claim`-Text. Der `claim`-Text DARF auch hier nicht als maschineller Diskriminator dienen. Soll eine Remote-Verifikation darüber hinaus maschinell als eigene Klasse unterscheidbar sein, erfordert das einen eigenen strukturierten Marker bzw. `type`-Eintrag analog `WotVerification` — kein freier Claim-Text.
+Diese Verifikation ist schwächer — sie beweist nur die Empfehlung durch einen gemeinsamen Kontakt, weder physische Identität noch eine Live-Interaktion. Sie ist **ungebunden (nicht-live)**: ihre `jti` bindet keine frische Challenge-Nonce. Eine ungebundene Verifikation trägt deshalb **kein** `WotVerification` und ist eine gewöhnliche `WotAttestation` (Discovery: `/p/{did}/a`, nicht `/p/{did}/v` — siehe [Sync 004](../03-wot-sync/004-discovery.md)). Ob nonce-gebunden (live) oder ungebunden, entscheidet die `jti` gemäß Acceptance Gate, NICHT der `claim`-Text. Soll eine ungebundene Verifikation später maschinell als eigene Klasse unterscheidbar sein, erfordert das einen eigenen strukturierten `type`-Eintrag analog `WotVerification` — kein freier Claim-Text.

--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -109,9 +109,9 @@ Im Normalfall sind beide Parteien mit einem Broker verbunden. Ein einziger QR-Sc
 
 ### Warum die Nonce entscheidend ist
 
-Die Nonce verbindet die digitale Attestation mit der physischen Begegnung. Alice zeigt einen QR-Code mit einer Nonce. Bob scannt ihn und baut die Nonce in seine Attestation-ID ein. Wenn Alice eine Attestation empfängt, deren ID ihre aktive Nonce enthält, weiß sie: diese Attestation kommt von jemandem, der gerade physisch ihren QR-Code gescannt hat.
+Die Nonce bindet die Attestation an eine **frische, live Challenge**. Alice zeigt einen QR-Code mit einer Nonce. Bob scannt ihn und baut die Nonce in seine Attestation-ID ein. Wenn Alice eine Attestation empfängt, deren ID ihre aktive Nonce enthält, weiß sie: diese Attestation entstand als Antwort auf ihre aktuelle, live Challenge — eine frische Live-Interaktion, nicht eine vorgefertigte oder wiedergespielte Attestation. In der intendierten Nutzung (QR-Scan vor Ort) heißt das, dass das Gegenüber gerade ihren QR-Code gescannt hat; der kryptographische Beweis ist die **Frische (Liveness)**, nicht physische Präsenz (eine Nonce könnte prinzipiell relayed werden).
 
-Ohne die Nonce könnte ein Angreifer zu einem beliebigen Zeitpunkt eine Verification-Attestation an Alice senden — ohne physisch anwesend gewesen zu sein.
+Ohne die Nonce könnte ein Angreifer zu einem beliebigen Zeitpunkt eine vorgefertigte Verification-Attestation an Alice senden — ohne jede live Interaktion.
 
 ### Warum kein Challenge-Hash?
 
@@ -212,11 +212,11 @@ Wenn kein Broker erreichbar ist (kein Internet, Festivalgelände, Krisenfall), f
 | | Online (ein QR-Scan) | Offline (zwei QR-Scans) |
 |---|---|---|
 | QR-Scans nötig | 1 | 2 |
-| Nonce-Verifikation | Ja (Nonce-Match beweist physische Anwesenheit) | Nein (menschliche Bestätigung statt Nonce-Match) |
+| Nonce-Verifikation | Ja (Nonce-Match beweist frische Live-Interaktion) | Nein (menschliche Bestätigung statt Nonce-Match) |
 | Zustellung | Sofort über Broker | Verzögert — bei nächster Broker-Verbindung |
 | Voraussetzung | Broker erreichbar für mindestens eine Partei | Keine |
 
-Die Offline-Verifikation ist etwas schwächer — sie hat keinen kryptographischen Beweis über die Nonce, dass der Gegenüber den QR-Code tatsächlich gescannt hat. Die Sicherheit liegt allein in der physischen Begegnung. Für den typischen Anwendungsfall (Festival, Workshop, Nachbarschaft) ist das ausreichend.
+Die Offline-Verifikation ist etwas schwächer — sie hat keine nonce-gebundene Frische-Garantie (keinen kryptographischen Beweis einer Live-Interaktion); die Sicherheit liegt allein in der beidseitigen menschlichen Bestätigung vor Ort. Für den typischen Anwendungsfall (Festival, Workshop, Nachbarschaft) ist das ausreichend.
 
 ## Verification-Attestation
 

--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -230,7 +230,7 @@ Jede Partei erstellt eine Verification-Attestation für die andere — als JWS-s
     "https://www.w3.org/ns/credentials/v2",
     "https://web-of-trust.de/vocab/v1"
   ],
-  "type": ["VerifiableCredential", "WotAttestation"],
+  "type": ["VerifiableCredential", "WotAttestation", "WotVerification"],
   "issuer": "did:key:z6Mk...bob",
   "credentialSubject": {
     "id": "did:key:z6Mk...alice",
@@ -244,6 +244,8 @@ Jede Partei erstellt eine Verification-Attestation für die andere — als JWS-s
   "jti": "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
 }
 ```
+
+Eine Verification-Attestation ist eine `WotAttestation` mit dem zusätzlichen `type`-Eintrag `WotVerification`. Dieser `type`-Eintrag ist der normative Diskriminator einer In-Person-Verifikation. Alle Attestation-Regeln aus [Trust 001](001-attestations.md) gelten unverändert, da das `type`-Array weiterhin `WotAttestation` enthält. Der `credentialSubject.claim`-Text (z.B. `"in-person verifiziert"`) ist ein menschenlesbares, frei lokalisierbares Label und DARF NICHT als Typ-Diskriminator verwendet werden. Clients und Broker MÜSSEN Verification-Attestations über den `WotVerification`-`type`-Eintrag erkennen, nicht über den `claim`-Wert.
 
 Die `jti` (Attestation-ID) einer online nonce-gebundenen Verification-Attestation MUSS die Nonce aus dem QR-Code exakt in dieser Form binden:
 

--- a/02-wot-trust/002-verifikation.md
+++ b/02-wot-trust/002-verifikation.md
@@ -299,4 +299,4 @@ Für Fälle wo kein Treffen möglich ist (z.B. Empfehlung durch einen gemeinsame
 3. Alice ruft Bobs Profil ab (inkl. Encryption Key) und erstellt eine Verification-Attestation
 4. Bob empfängt sie und kann gegenverifizieren (`counterVerify`)
 
-Die Verifikation ist schwächer als bei einem physischen Treffen — sie beweist nur die Empfehlung durch einen gemeinsamen Kontakt, nicht die physische Identität. Implementierungen DÜRFEN zwischen In-Person- und Remote-Verifikation unterscheiden (z.B. durch verschiedene Claim-Texte).
+Die Verifikation ist schwächer als bei einem physischen Treffen — sie beweist nur die Empfehlung durch einen gemeinsamen Kontakt, nicht die physische Identität. Ob eine Verification-Attestation nonce-gebunden (In-Person) oder ungebunden (Remote) ist, entscheidet die nonce-gebundene `jti` gemäß Acceptance Gate (siehe oben), NICHT der `claim`-Text. Der `claim`-Text DARF auch hier nicht als maschineller Diskriminator dienen. Soll eine Remote-Verifikation darüber hinaus maschinell als eigene Klasse unterscheidbar sein, erfordert das einen eigenen strukturierten Marker bzw. `type`-Eintrag analog `WotVerification` — kein freier Claim-Text.

--- a/03-wot-sync/004-discovery.md
+++ b/03-wot-sync/004-discovery.md
@@ -24,14 +24,14 @@ Der Profil-Service verwaltet pro DID drei separate, aber zusammengehörige JWS-D
 | Ressource | Pfad | Inhalt |
 |---|---|---|
 | **Profil** | `/p/{did}` | DID-Dokument plus öffentliches Profil (Name, Bio, Avatar, Protokolle) |
-| **Verifikationen** | `/p/{did}/v` | Liste empfangener In-Person-Verifikationen (Beweis des Web-of-Trust-Graphen) |
+| **Verifikationen** | `/p/{did}/v` | Liste empfangener Live-Verifikationen (Beweis des Web-of-Trust-Graphen) |
 | **Attestations** | `/p/{did}/a` | Liste bewusst veröffentlichter Attestations (öffentliche Aussagen die der Holder zeigen möchte) |
 
 Die Ressourcen werden unabhängig versioniert und aktualisiert.
 
 Empfangene Attestations landen zuerst in der privaten Wallet bzw. im Personal Doc des Holders. `/p/{did}/a` enthaelt nur Attestations, die der Holder bewusst veroeffentlicht hat. Der Profil-Service veroeffentlicht keine empfangenen Attestations automatisch.
 
-Die Zuordnung zwischen `/p/{did}/v` und `/p/{did}/a` ist disjunkt und erfolgt über den VC-`type`: Eine bewusst veröffentlichte Attestation, deren `type`-Array `WotVerification` enthält (siehe [Trust 002](../02-wot-trust/002-verifikation.md#verification-attestation)), gehört ausschließlich nach `/p/{did}/v`; jede andere veröffentlichte `WotAttestation` gehört nach `/p/{did}/a`. Keine veröffentlichte Attestation erscheint in beiden Listen. Die Klassifikation MUSS über den `type`-Eintrag erfolgen, nicht über den `claim`-Text.
+Die Zuordnung zwischen `/p/{did}/v` und `/p/{did}/a` ist disjunkt und erfolgt über den VC-`type`: Eine bewusst veröffentlichte Attestation, deren `type`-Array `WotVerification` enthält — also eine **Live-Verifikation** (siehe [Trust 002](../02-wot-trust/002-verifikation.md#verification-attestation)) — gehört ausschließlich nach `/p/{did}/v`; jede andere veröffentlichte `WotAttestation` (inkl. ungebundener, nicht-live Verifikationen) gehört nach `/p/{did}/a`. Keine veröffentlichte Attestation erscheint in beiden Listen. Die Klassifikation MUSS über den `type`-Eintrag erfolgen, nicht über den `claim`-Text.
 
 ### HTTP-API
 

--- a/03-wot-sync/004-discovery.md
+++ b/03-wot-sync/004-discovery.md
@@ -24,12 +24,12 @@ Der Profil-Service verwaltet pro DID drei separate, aber zusammengehörige JWS-D
 | Ressource | Pfad | Inhalt |
 |---|---|---|
 | **Profil** | `/p/{did}` | DID-Dokument plus öffentliches Profil (Name, Bio, Avatar, Protokolle) |
-| **Verifikationen** | `/p/{did}/v` | Liste empfangener Live-Verifikationen (Beweis des Web-of-Trust-Graphen) |
+| **Verifikationen** | `/p/{did}/v` | Liste der vom Holder **bewusst veröffentlichten** empfangenen Live-Verifikationen (kuratierter Beweis des Web-of-Trust-Graphen) |
 | **Attestations** | `/p/{did}/a` | Liste bewusst veröffentlichter Attestations (öffentliche Aussagen die der Holder zeigen möchte) |
 
 Die Ressourcen werden unabhängig versioniert und aktualisiert.
 
-Empfangene Attestations landen zuerst in der privaten Wallet bzw. im Personal Doc des Holders. `/p/{did}/a` enthaelt nur Attestations, die der Holder bewusst veroeffentlicht hat. Der Profil-Service veroeffentlicht keine empfangenen Attestations automatisch.
+Empfangene Live-Verifikationen und Attestations landen zuerst in der privaten Wallet bzw. im Personal Doc des Holders. `/p/{did}/v` und `/p/{did}/a` enthalten **ausschliesslich** Live-Verifikationen bzw. Attestations, die der Holder **bewusst veroeffentlicht** hat (Publish-Consent pro Eintrag). Der Profil-Service veroeffentlicht keine empfangenen Live-Verifikationen oder Attestations automatisch — beide Endpunkte sind oeffentlich, daher liegt die Veroeffentlichung jeder einzelnen empfangenen Verifikation/Attestation allein in der Entscheidung des Holders.
 
 Die Zuordnung zwischen `/p/{did}/v` und `/p/{did}/a` ist disjunkt und erfolgt über den VC-`type`: Eine bewusst veröffentlichte Attestation, deren `type`-Array `WotVerification` enthält — also eine **Live-Verifikation** (siehe [Trust 002](../02-wot-trust/002-verifikation.md#verification-attestation)) — gehört ausschließlich nach `/p/{did}/v`; jede andere veröffentlichte `WotAttestation` (inkl. ungebundener, nicht-live Verifikationen) gehört nach `/p/{did}/a`. Keine veröffentlichte Attestation erscheint in beiden Listen. Die Klassifikation MUSS über den `type`-Eintrag erfolgen, nicht über den `claim`-Text.
 
@@ -111,7 +111,7 @@ Das Profil enthält das DID-Dokument und soziale Profil-Daten in einem signierte
 {
   "did": "did:key:z6Mk...",
   "version": 5,
-  "verifications": [ /* Verification-VCs (JWS-Strings) */ ],
+  "verifications": [ /* Live-Verification-VCs (JWS-Strings), die der Holder bewusst veröffentlicht hat */ ],
   "updatedAt": "2026-04-22T10:00:00Z"
 }
 ```

--- a/03-wot-sync/004-discovery.md
+++ b/03-wot-sync/004-discovery.md
@@ -31,6 +31,8 @@ Die Ressourcen werden unabhängig versioniert und aktualisiert.
 
 Empfangene Attestations landen zuerst in der privaten Wallet bzw. im Personal Doc des Holders. `/p/{did}/a` enthaelt nur Attestations, die der Holder bewusst veroeffentlicht hat. Der Profil-Service veroeffentlicht keine empfangenen Attestations automatisch.
 
+Die Zuordnung zwischen `/p/{did}/v` und `/p/{did}/a` ist disjunkt und erfolgt über den VC-`type`: Eine bewusst veröffentlichte Attestation, deren `type`-Array `WotVerification` enthält (siehe [Trust 002](../02-wot-trust/002-verifikation.md#verification-attestation)), gehört ausschließlich nach `/p/{did}/v`; jede andere veröffentlichte `WotAttestation` gehört nach `/p/{did}/a`. Keine veröffentlichte Attestation erscheint in beiden Listen. Die Klassifikation MUSS über den `type`-Eintrag erfolgen, nicht über den `claim`-Text.
+
 ### HTTP-API
 
 **Medien-Typen:**


### PR DESCRIPTION
Löst die zwei Spec-Fragen, die `1.B.3-discovery-recovery` (TS-Referenz) blockierten — entschieden mit Anton 2026-06-12.

## #100 — Verification-Marker

Trust 002: Verification-Attestation bekommt den zusätzlichen `type`-Eintrag `WotVerification` als **normativen Diskriminator**. Begründung: In VCs ist `type` der Klassen-Diskriminator; der bisherige De-facto-Marker war der deutschsprachige Freitext `claim === "in-person verifiziert"` (in der Referenz-Impl 6× hartcodiert) — sprachabhängig und fragil. `WotVerification` ist additiv: das `type`-Array enthält weiterhin `WotAttestation`, alle Trust-001-Regeln gelten unverändert. Der `claim`-Text wird explizit zum nicht-normativen, lokalisierbaren Label.

## #34 (Teil) — disjunkter `/v`÷`/a`-Split

Sync 004: `WotVerification` → ausschließlich `/p/{did}/v`, sonstige `WotAttestation` → `/p/{did}/a`, disjunkt, Klassifikation MUSS über `type` (nicht `claim`). PublicProfile zeigt die Vereinigung — keine Nutzer-sichtbare Änderung.

## Bewusst NICHT in dieser PR (bleibt #34)

- Dedizierte JSON-Schemas + Conformance-Vektoren für `/v`+`/a` (Manifest-Arbeit).
- Ressourcen-spezifischer JWS-`typ`-Header: nicht nötig — URL-Pfad + discriminated-union-Payload disambiguieren bereits; generisches Identity-002-JWS genügt.
- `profile` additionalProperties (Krypto-Key-Verbot): Prosa sagt es via Z.153 bereits; Schema-Verschärfung kommt mit den Vektoren.

## Validierung

`npm run validate` grün (spec consistency 44 JSON / 21 md-refs, didcomm-node + @veramo/did-comm ok); neuer Cross-Doc-Anchor löst auf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Updated the Verification–Attestation spec to introduce `WotVerification` as a normative discriminator for nonce-bound “Live-Verifikationen”, refining acceptance behavior and clarifying that live vs non-live classification relies on `type` (not `claim` text).
* Clarified discovery rules for Profile-Service lists: map published `WotAttestation` to `/p/{did}/v` only when `type` includes `WotVerification`; otherwise it belongs exclusively in `/p/{did}/a` (including handling of unbound verifications).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->