### PR TITLE
spec(sync-004): /v+/a List-Resource-Schema + Conformance-Vektoren + profile-Key-Verbot (refs #34)

### DIFF
--- a/conformance/manifest.json
+++ b/conformance/manifest.json
@@ -32,7 +32,7 @@
       "test_vectors": [
         {
           "file": "test-vectors/phase-1-interop.json",
-          "sections": ["attestation_vc_jws", "trust002_jti_nonce_binding"]
+          "sections": ["attestation_vc_jws", "verification_vc_jws", "trust002_jti_nonce_binding"]
         }
       ]
     },
@@ -54,6 +54,7 @@
         "schemas/log-entry-payload.schema.json",
         "schemas/member-update.schema.json",
         "schemas/profile-service-response.schema.json",
+        "schemas/profile-service-list-resource.schema.json",
         "schemas/space-invite.schema.json"
       ],
       "test_vectors": [
@@ -69,6 +70,8 @@
             "space_capability_jws",
             "space_membership_messages",
             "sync_heads_disposition",
+            "profile_service_put_acceptance",
+            "profile_service_rollback",
             "admin_key_derivation",
             "personal_doc"
           ]

--- a/schemas/examples/invalid/profile-service-list-resource.json
+++ b/schemas/examples/invalid/profile-service-list-resource.json
@@ -1,0 +1,11 @@
+{
+  "did": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+  "version": 5,
+  "verifications": [
+    "eyJhbGciOiJFZERTQSJ9.eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl19.c2ln"
+  ],
+  "attestations": [
+    "eyJhbGciOiJFZERTQSJ9.eyJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIl19.c2ln"
+  ],
+  "updatedAt": "2026-04-22T10:00:00Z"
+}

--- a/schemas/examples/valid/profile-service-list-resource.json
+++ b/schemas/examples/valid/profile-service-list-resource.json
@@ -1,0 +1,8 @@
+{
+  "did": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+  "version": 5,
+  "verifications": [
+    "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoidmMrand0In0.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiXSwidHlwZSI6WyJWZXJpZmlhYmxlQ3JlZGVudGlhbCIsIldvdEF0dGVzdGF0aW9uIiwiV290VmVyaWZpY2F0aW9uIl19.tuVMtbFqSgss7EismlbJuN-y8P0DbbJyMbP3H_GZfNvFIvYL826FwS3gynYuGzGuMNrpkfKG7jsC2mG38IHlBg"
+  ],
+  "updatedAt": "2026-04-22T10:00:00Z"
+}

--- a/schemas/profile-service-list-resource.schema.json
+++ b/schemas/profile-service-list-resource.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://web-of-trust.de/schemas/profile-service-list-resource.schema.json",
+  "title": "WoT Profile Service List Resource (/p/{did}/v and /p/{did}/a)",
+  "description": "Verifications- und Attestations-Listen-Ressourcen sind eigenstaendige JWS-Ressourcen ohne didDocument/profile. Genau eines von verifications oder attestations; Items sind Compact-JWS-Strings (Verifiable Credentials). Eigene monotone version.",
+  "type": "object",
+  "required": ["did", "version", "updatedAt"],
+  "additionalProperties": false,
+  "oneOf": [
+    { "required": ["verifications"], "not": { "required": ["attestations"] } },
+    { "required": ["attestations"], "not": { "required": ["verifications"] } }
+  ],
+  "properties": {
+    "did": { "type": "string", "pattern": "^did:[a-z0-9]+:.+" },
+    "version": { "type": "integer", "minimum": 0 },
+    "verifications": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$" }
+    },
+    "attestations": {
+      "type": "array",
+      "items": { "type": "string", "pattern": "^[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+\\.[A-Za-z0-9_-]+$" }
+    },
+    "updatedAt": { "type": "string", "format": "date-time" }
+  }
+}

--- a/schemas/profile-service-response.schema.json
+++ b/schemas/profile-service-response.schema.json
@@ -13,7 +13,15 @@
       "type": "object",
       "required": ["name"],
       "additionalProperties": true,
-      "not": { "required": ["encryptionPublicKey"] },
+      "not": { "anyOf": [
+        { "required": ["encryptionPublicKey"] },
+        { "required": ["keyAgreement"] },
+        { "required": ["verificationMethod"] },
+        { "required": ["publicKey"] },
+        { "required": ["publicKeyMultibase"] },
+        { "required": ["publicKeyJwk"] },
+        { "required": ["privateKey"] }
+      ] },
       "properties": {
         "name": { "type": "string", "minLength": 1 },
         "bio": { "type": "string" },

--- a/scripts/validate_test_vectors.py
+++ b/scripts/validate_test_vectors.py
@@ -492,6 +492,40 @@ def main() -> None:
     verify_jws(attestation["jws"], ed_pub)
     print("attestation vc jws ok")
 
+    verification = data["verification_vc_jws"]
+    vheader_b64, vpayload_b64, vsig_b64 = verification["jws"].split(".")
+    assert json.loads(b64u_decode(vheader_b64)) == verification["header"]
+    assert json.loads(b64u_decode(vpayload_b64)) == verification["payload"]
+    assert hashlib.sha256(jcs(verification["payload"])).hexdigest() == verification["payload_jcs_sha256"]
+    assert f"{vheader_b64}.{vpayload_b64}" == verification["signing_input"]
+    assert vsig_b64 == verification["signature_b64"]
+    assert verification["header"]["typ"] == "vc+jwt"
+    assert verification["header"]["kid"] == identity["kid"]
+    assert verification["payload"]["issuer"] == identity["did"]
+    assert verification["payload"]["iss"] == identity["did"]
+    assert verification["payload"]["credentialSubject"]["id"] == verification["payload"]["sub"]
+    # WotVerification ist der normative Diskriminator (Trust 002), nicht der claim-Text.
+    assert "WotVerification" in verification["payload"]["type"]
+    assert "WotAttestation" in verification["payload"]["type"]
+    verify_jws(verification["jws"], ed_pub)
+    print("verification vc jws ok")
+
+    # Sync 004 Z.155-164: PUT akzeptiert nur strikt groessere version (sonst 409).
+    for case in data["profile_service_put_acceptance"]["cases"]:
+        stored = case["stored_version"]
+        accept = stored is None or case["new_version"] > stored
+        expected = "accept" if accept else "conflict"
+        assert expected == case["expected"], case["name"]
+    print("profile service put acceptance ok")
+
+    # Sync 004 Z.166-183: gelieferte version < zuletzt gesehene -> Rollback (pro Ressource).
+    for case in data["profile_service_rollback"]["cases"]:
+        seen = case["last_seen_version"]
+        rollback = seen is not None and case["fetched_version"] < seen
+        expected = "rollback" if rollback else "ok"
+        assert expected == case["expected"], case["name"]
+    print("profile service rollback ok")
+
     ecies = data["ecies"]
     eph_public = b64u_decode(ecies["ephemeral_public_b64"])
     shared = x25519.X25519PrivateKey.from_private_bytes(x_seed).exchange(

--- a/test-vectors/README.md
+++ b/test-vectors/README.md
@@ -260,6 +260,9 @@ Die folgenden Vektoren sind in [`phase-1-interop.md`](phase-1-interop.md) dokume
 - **Broker Control-Frame Device-Revoke** - geschlossener `device-revoke`-Frame mit `revocationJws`, innerem JWS-Payload und malformed Top-Level-Formen.
 - **Space Capability** - JWS-Signatur mit `spaceCapabilitySigningKey`, Broker-Verifikation.
 - **Sync Heads Disposition** - Schliesst real-life-org/wot-spec#49 fuer Phase 1: reine JSON-Dispositionsvektoren fuer das Ableiten der naechsten `seq` aus `heads`, das Ablehnen ungueltiger Head-`seq`-Werte, den `Number.MAX_SAFE_INTEGER`-Overflow-Guard, die `sync-response`-`truncated`-Disposition (`request-next-page` vs. `complete`) und den Heads-Vergleich (identisch -> `consistent`, abweichende Werte oder fehlende/extra Device-Keys -> `divergent`). Keine Signaturen, keine generierten Bytes.
+- **Verification VC JWS** (Trust 002) - signiertes Verifiable Credential mit dem `type`-Eintrag `WotVerification` als normativem Diskriminator (zusaetzlich zu `WotAttestation`); der `claim`-Text ist nur ein Label. Re-verifizierte Signatur, JCS-SHA-256 und `signing_input` wie bei Attestation VC JWS.
+- **Profile Service PUT Acceptance** (Sync 004) - reine JSON-Dispositionsvektoren fuer die serverseitige Versions-Monotonie: nur strikt groessere `version` als die gespeicherte wird akzeptiert, sonst `conflict` (409). Resource-agnostisch fuer `/p`, `/p/{did}/v`, `/p/{did}/a`. Keine Signaturen.
+- **Profile Service Rollback** (Sync 004) - reine JSON-Dispositionsvektoren fuer den Client-Rollback-Schutz: gelieferte `version` kleiner als die zuletzt gesehene -> `rollback`, sonst `ok`; unabhaengig pro Ressource (Z.181). Keine Signaturen.
 - **DID-Dokument** - `resolve()` fuer `did:key` plus Bootstrap-`keyAgreement`.
 - **Admin Key Ableitung** - HKDF mit Space-ID im Info-String.
 - **Personal Doc Key** - deterministische Document-ID.

--- a/test-vectors/phase-1-interop.json
+++ b/test-vectors/phase-1-interop.json
@@ -746,5 +746,102 @@
         { "name": "future-iat", "payload": { "iat": 1776852001, "exp": 1808050800 }, "expected_error": "future-iat" }
       ]
     }
+  },
+  "verification_vc_jws": {
+    "header": {
+      "alg": "EdDSA",
+      "kid": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a#sig-0",
+      "typ": "vc+jwt"
+    },
+    "payload": {
+      "@context": [
+        "https://www.w3.org/ns/credentials/v2",
+        "https://web-of-trust.de/vocab/v1"
+      ],
+      "type": [
+        "VerifiableCredential",
+        "WotAttestation",
+        "WotVerification"
+      ],
+      "issuer": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+      "credentialSubject": {
+        "id": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+        "claim": "in-person verifiziert"
+      },
+      "validFrom": "2026-04-21T10:00:00Z",
+      "iss": "did:key:z6Mko3ZEjKJWQAM5nDXKoZ9jErvvxbWbYgS8KJXYpC5Hbu8a",
+      "sub": "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH",
+      "nbf": 1776765600,
+      "jti": "urn:uuid:550e8400-e29b-41d4-a716-446655440000"
+    },
+    "payload_jcs_sha256": "b9d9f0e0afb14f0ff017f1f347c09d67a8c56b6576db1d2dfcd37154ca11aae5",
+    "signing_input": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoidmMrand0In0.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3dlYi1vZi10cnVzdC5kZS92b2NhYi92MSJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJjbGFpbSI6ImluLXBlcnNvbiB2ZXJpZml6aWVydCIsImlkIjoiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgifSwiaXNzIjoiZGlkOmtleTp6Nk1rbzNaRWpLSldRQU01bkRYS29aOWpFcnZ2eGJXYllnUzhLSlhZcEM1SGJ1OGEiLCJpc3N1ZXIiOiJkaWQ6a2V5Ono2TWtvM1pFaktKV1FBTTVuRFhLb1o5akVydnZ4YldiWWdTOEtKWFlwQzVIYnU4YSIsImp0aSI6InVybjp1dWlkOjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsIm5iZiI6MTc3Njc2NTYwMCwic3ViIjoiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiV290QXR0ZXN0YXRpb24iLCJXb3RWZXJpZmljYXRpb24iXSwidmFsaWRGcm9tIjoiMjAyNi0wNC0yMVQxMDowMDowMFoifQ",
+    "signature_b64": "tuVMtbFqSgss7EismlbJuN-y8P0DbbJyMbP3H_GZfNvFIvYL826FwS3gynYuGzGuMNrpkfKG7jsC2mG38IHlBg",
+    "jws": "eyJhbGciOiJFZERTQSIsImtpZCI6ImRpZDprZXk6ejZNa28zWkVqS0pXUUFNNW5EWEtvWjlqRXJ2dnhiV2JZZ1M4S0pYWXBDNUhidThhI3NpZy0wIiwidHlwIjoidmMrand0In0.eyJAY29udGV4dCI6WyJodHRwczovL3d3dy53My5vcmcvbnMvY3JlZGVudGlhbHMvdjIiLCJodHRwczovL3dlYi1vZi10cnVzdC5kZS92b2NhYi92MSJdLCJjcmVkZW50aWFsU3ViamVjdCI6eyJjbGFpbSI6ImluLXBlcnNvbiB2ZXJpZml6aWVydCIsImlkIjoiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgifSwiaXNzIjoiZGlkOmtleTp6Nk1rbzNaRWpLSldRQU01bkRYS29aOWpFcnZ2eGJXYllnUzhLSlhZcEM1SGJ1OGEiLCJpc3N1ZXIiOiJkaWQ6a2V5Ono2TWtvM1pFaktKV1FBTTVuRFhLb1o5akVydnZ4YldiWWdTOEtKWFlwQzVIYnU4YSIsImp0aSI6InVybjp1dWlkOjU1MGU4NDAwLWUyOWItNDFkNC1hNzE2LTQ0NjY1NTQ0MDAwMCIsIm5iZiI6MTc3Njc2NTYwMCwic3ViIjoiZGlkOmtleTp6Nk1rcFRIUjhWTnNCeFlBQVdIdXQyR2VhZGQ5alN3dUJWOHhSb0Fud1dzZHZrdEgiLCJ0eXBlIjpbIlZlcmlmaWFibGVDcmVkZW50aWFsIiwiV290QXR0ZXN0YXRpb24iLCJXb3RWZXJpZmljYXRpb24iXSwidmFsaWRGcm9tIjoiMjAyNi0wNC0yMVQxMDowMDowMFoifQ.tuVMtbFqSgss7EismlbJuN-y8P0DbbJyMbP3H_GZfNvFIvYL826FwS3gynYuGzGuMNrpkfKG7jsC2mG38IHlBg"
+  },
+  "profile_service_put_acceptance": {
+    "notes": "Sync 004 Z.155-164 Server-PUT-Versions-Monotonie (resource-agnostisch fuer /p, /v, /a). Reine Dispositionsvektoren ueber deterministische Inputs; keine Signaturen.",
+    "spec_refs": [
+      "03-wot-sync/004-discovery.md#signatur-pruefung-beim-put",
+      "03-wot-sync/004-discovery.md#versionierung-und-rollback-schutz"
+    ],
+    "cases": [
+      {
+        "name": "first-version-no-stored",
+        "stored_version": null,
+        "new_version": 1,
+        "expected": "accept"
+      },
+      {
+        "name": "strictly-greater",
+        "stored_version": 5,
+        "new_version": 6,
+        "expected": "accept"
+      },
+      {
+        "name": "equal-rejected",
+        "stored_version": 5,
+        "new_version": 5,
+        "expected": "conflict"
+      },
+      {
+        "name": "lower-rejected",
+        "stored_version": 7,
+        "new_version": 6,
+        "expected": "conflict"
+      }
+    ]
+  },
+  "profile_service_rollback": {
+    "notes": "Sync 004 Z.166-183 Client-Rollback-Schutz, unabhaengig pro Ressource (Z.181). Reine Dispositionsvektoren; keine Signaturen.",
+    "spec_refs": [
+      "03-wot-sync/004-discovery.md#versionierung-und-rollback-schutz"
+    ],
+    "cases": [
+      {
+        "name": "first-fetch-no-baseline",
+        "last_seen_version": null,
+        "fetched_version": 3,
+        "expected": "ok"
+      },
+      {
+        "name": "same-version",
+        "last_seen_version": 4,
+        "fetched_version": 4,
+        "expected": "ok"
+      },
+      {
+        "name": "newer-version",
+        "last_seen_version": 4,
+        "fetched_version": 9,
+        "expected": "ok"
+      },
+      {
+        "name": "older-version-rollback",
+        "last_seen_version": 9,
+        "fetched_version": 8,
+        "expected": "rollback"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Die Conformance-Artefakte für den Profil-Service (#34), **gestackt auf #101** (WotVerification-Marker). Base ist `spec/verification-type-marker`, damit der Diff nur die #34-Änderungen zeigt — **bitte nach #101 mergen** (Base retargetet dann auf `main`).

## Was rein kommt

**1. List-Resource-Schema** (`schemas/profile-service-list-resource.schema.json` + valid/invalid Examples): `/p/{did}/v` und `/p/{did}/a` als eigenständige JWS-Listen-Ressourcen — `did`/`version`/`updatedAt` + **genau eines** von `verifications`/`attestations` (oneOf), Items sind Compact-JWS-Strings, eigene monotone `version`. (#34 Q2)

**2. Conformance-Vektoren** in `phase-1-interop.json`:
- `verification_vc_jws` — **signiertes** VC mit `type`-Eintrag `WotVerification` (kanonische Test-Identität, re-verifizierte Signatur + JCS-SHA-256 + `signing_input`). Der konkrete Cross-Impl-Diskriminator für den `/v`÷`/a`-Split aus #101.
- `profile_service_put_acceptance` — Server-Versions-Monotonie (strikt-größer → accept, sonst 409), resource-agnostisch.
- `profile_service_rollback` — Client-Rollback (fetched < last-seen → rollback), unabhängig pro Ressource (Z.181).
- Beide Disposition-Sektionen mit py-Validator-Handlern (rechnen die Entscheidung nach), Muster wie `sync_heads_disposition`.

**3. profile-Schema verschärft** (`profile-service-response.schema.json`): kryptographisches Schlüsselmaterial im `profile`-Objekt verboten (`encryptionPublicKey`/`keyAgreement`/`verificationMethod`/`publicKey…`) — Sync 004 Z.153 („Keys ausschließlich im didDocument"). (#34 Q3)

## #34 Q1 (typ-Header)

Bleibt bei generischem Identity-002-JWS — kein ressourcen-spezifisches `typ`. URL-Pfad + discriminated-union-Payload disambiguieren bereits. Im Issue dokumentiert.

## Validierung

`npm run validate` grün: conformance (wot-sync 8 schemas / 13 vector-sections, wot-trust 3 sections), schemas (List-Resource valid ok + invalid rejected), vectors (`verification vc jws ok`, `put acceptance ok`, `rollback ok` — Signatur re-verifiziert), consistency (47 JSON / 21 md-refs), didcomm.

## Slice-Bezug

Tightens den TS-Slice `1.B.3-discovery-recovery`: dessen Pflicht-Tests validieren künftig gegen diese Vektoren (ProtocolInterop-Stil) statt nur gegen Prosa. Dispatch-Gate des Slices = nach Merge von #101 **und** dieser PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
