### PR TITLE
spec(sync): capability-gated ingest + provisioning frames + docId==spaceId + log-author binding

### DIFF
--- a/03-wot-sync/002-sync-protokoll.md
+++ b/03-wot-sync/002-sync-protokoll.md
@@ -46,6 +46,16 @@ Neue Devices MÜSSEN ihre `deviceId` als kanonische lowercase UUID v4 erzeugen. 
 
 Alle `deviceId`- und `docId`-Werte im Sync-Log MÜSSEN als kanonische lowercase UUID v4 serialisiert werden. Deterministische Document-IDs, z.B. die Personal-Doc-ID aus [Sync 006](006-personal-doc.md#deterministische-document-id), MÜSSEN beim Formatieren die UUID-v4-Version- und Variant-Bits setzen.
 
+## docId und spaceId
+
+`docId` ist der Dokument-Namespace des Logs (UUID v4). Für **Space-Dokumente** gilt in `wot-sync@0.1` **`docId == spaceId`**: ein Space hat genau ein Sync-Dokument, dessen `docId` die `spaceId` ist. Der Broker leitet den Capability-Scope (`spaceId`) deterministisch aus der `docId` ab (siehe [Sync 003 Capability-Prüfung](003-transport-und-broker.md#capability-prüfung-am-broker)).
+
+Für das **Personal-Doc** ist `docId` die deterministische Personal-Doc-ID (siehe [Sync 006](006-personal-doc.md#deterministische-document-id)); es gibt keine `spaceId`, die Capability ist self-issued.
+
+Implementierungen, deren CRDT-Schicht eine eigene native Dokument-ID verwendet (z.B. Automerge), MÜSSEN am Wire dennoch die UUID-v4-`docId` (= `spaceId` bzw. Personal-Doc-ID) führen und ihre native ID intern darauf mappen.
+
+**Grenze:** Mehrere Sync-Dokumente pro Space (z.B. selektives Teilen einzelner Items) sind nicht Teil von `wot-sync@0.1`. Eine künftige Extension, die das einführt, MUSS ein explizites `docId → spaceId`-Mapping definieren, statt `docId == spaceId` anzunehmen.
+
 ## Log
 
 Jeder Peer führt einen Append-only Log pro Dokument. Jeder Eintrag ist ein verschlüsselter Blob — das Protokoll weiß nicht was drin ist.

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -248,7 +248,9 @@ Eine Capability ist ein JWS, signiert mit dem **Space Capability Signing Key**:
 | `issuedAt` | ISO 8601 | Ja | Erstellungszeitpunkt |
 | `validUntil` | ISO 8601 | Ja | Ablaufzeitpunkt — nach diesem Moment ist die Capability ungültig |
 
-Der JWS wird mit dem Space Capability Signing Key signiert. Der `kid` im JWS-Header MUSS den Space-Kontext und die Capability-Key-Generation referenzieren: `wot:space:<spaceId>#cap-<generation>`. Der Broker verifiziert mit dem aktuellen Space Capability Verification Key für genau diesen Space und diese Generation.
+Das Feld `type` ist immer `"capability"`. Der JWS wird mit dem Space Capability Signing Key signiert. Der `kid` im JWS-Header MUSS den Space-Kontext und die Capability-Key-Generation referenzieren: `wot:space:<spaceId>#cap-<generation>`. Der Broker verifiziert mit dem aktuellen Space Capability Verification Key für genau diesen Space und diese Generation.
+
+Für **persönliche Dokumente** wird dasselbe Payload-Schema mit festen Bindungen und einem abweichenden `kid` (Identity-Key statt Space-Key) verwendet — siehe [Persönliche Dokumente](#persönliche-dokumente).
 
 **Empfohlene Gültigkeitsdauer:**
 
@@ -339,9 +341,22 @@ Der JWS-Payload MUSS exakt `{ "type": "admin-add", "spaceId": "<uuid>", "newAdmi
 
 Für das persönliche Dokument (Identität, Keys) stellt der User sich seine eigene Capability aus. Das persönliche Dokument hat kein Space Capability Key Pair — stattdessen signiert der User die Capability direkt mit seinem **Identity Key** (DID).
 
+**Wire-Form (MUSS).** Die Personal-Doc-Capability nutzt **dasselbe Payload-Schema** wie die Space-Capability ([Capability-Format](#capability-format)) mit folgenden festen Bindungen — kein separater Payload-Typ, kein zusätzliches `issuer`-Feld:
+
+| Feld | Wert bei Personal-Doc |
+|------|----------------------|
+| `type` | `"capability"` |
+| `spaceId` | die deterministische **Personal-Doc-ID** (= `docId`, siehe [Sync 006](006-personal-doc.md#deterministische-document-id)) |
+| `audience` | die Owner-DID |
+| `permissions` | `["read", "write"]` |
+| `generation` | `0` — Personal-Docs werden in `wot-sync@0.1` **nicht** rotiert; der Scope-Cache speichert Generation `0` |
+| `issuedAt` / `validUntil` | wie bei Space-Capabilities |
+
+Der `kid` im JWS-Header MUSS die **Verification-Method-ID des Identity Keys** des Owners sein (`<did>#<vm>`, **nicht** `wot:space:…`); signiert wird mit dem Identity Key. Ein separates `issuer`-Feld entfällt — der „Issuer" ist implizit die `kid`-DID, und die self-issued-Bedingung ist `kid`-DID = `audience` = authentifizierte DID.
+
 **Broker-Erkennung (MUSS).** Der Broker unterscheidet den Pfad anhand der `space-register`-Eintragung für die `docId`:
 
-- Existiert **keine** `space-register`-Eintragung für `docId` → Personal-Doc-Pfad: Der Broker resolved die authentifizierte DID zu ihrem Ed25519 Identity Key, verifiziert das Capability-JWS damit und prüft `issuer` = `audience` = authentifizierte DID. Der Broker kann **nicht** kryptographisch beweisen, dass `docId` die deterministische Personal-Doc-ID *dieser* DID ist (sie ist seed-abgeleitet, broker-blind); das ist unkritisch, weil der Personal-Pfad ausschließlich Selbst-Autorisierung erlaubt (`issuer==audience==auth-DID`) und Personal-Doc-Inhalt unter einem nur dem Eigentümer bekannten Schlüssel liegt.
+- Existiert **keine** `space-register`-Eintragung für `docId` → Personal-Doc-Pfad: Der Broker resolved die authentifizierte DID zu ihrem Ed25519 Identity Key, verifiziert das Capability-JWS damit und prüft `kid`-DID = `audience` = authentifizierte DID sowie `spaceId` = `docId` (Wire-Form oben). Der Broker kann **nicht** kryptographisch beweisen, dass `docId` die deterministische Personal-Doc-ID *dieser* DID ist (sie ist seed-abgeleitet, broker-blind); das ist unkritisch, weil der Personal-Pfad ausschließlich Selbst-Autorisierung erlaubt (`kid`-DID = `audience` = auth-DID) und Personal-Doc-Inhalt unter einem nur dem Eigentümer bekannten Schlüssel liegt.
 - Existiert **eine** `space-register`-Eintragung für `docId` → greift **nur** der Space-Pfad; ein self-issued-Versuch auf eine registrierte `docId` wird abgelehnt. Damit kann der Personal-Pfad keine Space-`docId` umgehen.
 
 **Unterschied zum Space-Capability-Modell:** Bei Spaces signiert der geteilte `spaceCapabilitySigningKey`, bei Personal Docs signiert der persönliche Identity Key (DID). Das ist eine bewusste Vereinfachung — ein Personal Doc hat genau einen Eigentümer, kein Gruppen-Key-Management nötig. Die Capability-Felder (`spaceId`, `generation`, `validUntil`) werden analog verwendet, aber `spaceId` wird durch die deterministische Personal-Doc-ID ersetzt (siehe [Sync 006](006-personal-doc.md)).
@@ -544,7 +559,17 @@ Ein Peer publiziert einen neuen Log-Eintrag an andere Peers. Der Log-Eintrag sel
 
 Der JWS-Payload des Eintrags enthält die Felder `seq`, `deviceId`, `docId`, `authorKid`, `keyGeneration`, `data`, `timestamp` — JCS-kanonisiert, Ed25519-signiert. Vollständiges Schema in [Sync 002 Log-Eintrag](002-sync-protokoll.md#log-eintrag).
 
-**Broker-Indexing:** Der Broker extrahiert `docId`, `deviceId`, `seq` aus dem JWS-Payload (Base64URL-dekodieren des mittleren Segments, JCS-kanonisiertes JSON parsen). Diese drei Felder braucht er für Indexing, Sync-Anfragen und Kollisionserkennung. Der Broker MUSS die JWS-Signatur NICHT verifizieren — Signatur-Verifikation ist Aufgabe der Peers, die die Einträge letztendlich konsumieren. Der Broker darf sie aber als zusätzliche Integritätsprüfung durchführen.
+**Broker-Ingest-Verifikation (MUSS).** Für den durablen Log (nicht mehr transiente Queue) MUSS der Broker den Log-Entry-JWS **vollständig verifizieren, bevor** er Autor-Bindung, Content-Hash/Kollisionsprüfung und Store/Relay durchführt:
+
+1. `alg = EdDSA` (Algorithmus-Validierung, siehe [Identity 002](../01-wot-identity/002-signaturen-und-verifikation.md#algorithmus-validierung-muss));
+2. DID aus `authorKid` extrahieren (Teil vor `#`), via `resolve()` den Public Key der passenden `verificationMethod` bestimmen;
+3. JWS-Signatur gegen diesen Public Key gültig;
+4. `kid == authorKid` (Header-`kid` identisch zum Payload-`authorKid`);
+5. Payload-Schema vollständig (`seq`, `deviceId`, `docId`, `authorKid`, `keyGeneration`, `data`, `timestamp`).
+
+Schlägt eine dieser Prüfungen fehl → `AUTH_INVALID`; der Eintrag wird **weder gespeichert noch relayed**. Erst nach erfolgreicher Verifikation extrahiert der Broker die jetzt **authentifizierten** Felder `docId`, `deviceId`, `seq` für Indexing, [Autor-Bindung](#log-eintrag-autor-bindung-muss), Kollisionserkennung und Sync-Anfragen.
+
+Ohne diese Pflicht-Verifikation würde die Autor-Bindung ins Leere laufen: ein Angreifer könnte einen JWS mit fremder `deviceId` und passend gesetztem `authorKid`-Payload, aber **eigener** Signatur einschleusen — der Broker würde den `(docId, deviceId, seq)`-Slot im durablen Log dauerhaft vergiften, obwohl der Angreifer die fremde DID nicht kontrolliert. (In der früheren transienten Queue war Signaturprüfung optional, weil der Log nicht persistierte; das gilt nicht mehr.)
 
 Kein ACK nötig — der Empfang wird implizit durch den nächsten `sync-request` bestätigt (fehlende seq-Werte werden nachgefordert).
 

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -183,6 +183,12 @@ Der Broker speichert pro DID mindestens `deviceId`, `firstSeenAt`, `lastSeenAt`,
 
 Der Broker MUSS Revocations atomisch anwenden. Wenn Registrierung und Revocation für dieselbe `deviceId` konkurrieren, gewinnt die Revocation und die Registrierung wird mit `DEVICE_REVOKED` abgelehnt. Ist eine `deviceId` bereits für eine andere DID registriert, MUSS der Broker mit `DEVICE_ID_CONFLICT` ablehnen.
 
+### Log-Eintrag-Autor-Bindung (MUSS)
+
+Beim Ingest eines `log-entry/1.0` MUSS der Broker prüfen, dass die aus `authorKid` extrahierte DID (Teil vor `#`, siehe [Sync 002](002-sync-protokoll.md#signatur-des-log-eintrags)) exakt die DID ist, die `deviceId` in der Broker-Device-Liste besitzt. Andernfalls Ablehnung mit `AUTHOR_MISMATCH`; der Eintrag wird **weder gespeichert noch relayed**. Diese Bindung verankert die `(docId, deviceId, seq)`-Autorität an der registrierten `(did, deviceId)`-Kombination (`deviceId` global eindeutig, siehe [Device-Liste](#device-liste-im-broker)) und verhindert, dass ein gültig signierender Autor unter einer fremden `deviceId` schreibt. Sie ist der autoritative Anker und ersetzt brokerlokale First-Writer-Wins-Heuristiken auf `(docId, deviceId)`.
+
+**Grenze (Shared-Seed):** Im Shared-Seed-Modell teilen alle Geräte eines Users dieselbe DID; die Bindung filtert dann fremde DIDs, nicht Geräte derselben DID. Geräte-granulare Autorität erfordert per-device Keys (Identity 004 / Phase 2).
+
 ## Store-and-Forward pro Device
 
 Inbox-Nachrichten werden **pro Device** zwischengespeichert, nicht pro DID. Das garantiert, dass jedes Device die für es bestimmten Nachrichten erhält, auch wenn es vorübergehend offline ist.
@@ -260,16 +266,21 @@ Capabilities werden zusammen mit den Space-Schlüsseln verteilt:
 
 ### Capability-Prüfung am Broker
 
-Wenn ein Client ein Dokument syncen will:
+**Präsentation (session-scoped, MUSS).** Eine Capability wird **einmal pro Session** präsentiert, nicht pro Nachricht. Nach dem Handshake sendet der Client für jedes Dokument, das er nutzen will, einen `present-capability`-Control-Frame (siehe [Control-Frame-Vokabular](#broker-control-frames-normativ)). Der Broker verifiziert die Capability und **cached den erlaubten Scope pro `(WebSocket, docId)`**. Folgende `log-entry`- und `sync-request`-Nachrichten werden gegen diesen Cache geprüft — ohne erneute Capability. Das folgt der Authentizität-pro-Message-Typ-Regel ([§Authentizität](#authentizität-pro-message-typ-normativ)): Autorität über den authentifizierten Kanal, keine doppelte Auth.
 
-1. Client sendet seine Capability
-2. Broker prüft:
-   - JWS-Signatur gültig gegen den aktuellen `spaceCapabilityVerificationKey`? (inklusive `alg=EdDSA`, siehe [Identity 002](../01-wot-identity/002-signaturen-und-verifikation.md#algorithmus-validierung-muss))
-   - `audience` = authentifizierte DID?
-   - `spaceId` = angefragter Space?
-   - `generation` = aktuelle Capability-Key-Generation? (alte Capabilities werden damit implizit widerrufen)
-   - `now < validUntil`? (nicht abgelaufen)
-3. OK → Sync erlaubt
+**Verifikation bei `present-capability` (MUSS).** Der Broker bestimmt zuerst den Pfad anhand der `docId`:
+
+- **Space-Dokument** (für `docId` existiert eine `space-register`-Eintragung): Capability-JWS gültig gegen den aktuellen `spaceCapabilityVerificationKey` dieses Space (inklusive `alg=EdDSA`, siehe [Identity 002](../01-wot-identity/002-signaturen-und-verifikation.md#algorithmus-validierung-muss)); `audience` = authentifizierte DID; `spaceId` = `docId` (für Space-Dokumente gilt `docId == spaceId`, siehe [Sync 002](002-sync-protokoll.md#docid-und-spaceid)); `generation` = aktuelle Capability-Key-Generation; `now < validUntil`.
+- **Persönliches Dokument** (für `docId` existiert **keine** `space-register`-Eintragung): self-issued Capability — siehe [Persönliche Dokumente](#persönliche-dokumente).
+
+Der gecachte Scope MUSS die `permissions` (`read`/`write`) **und** die `generation` der Capability mitführen.
+
+**Gate (MUSS).** Der Capability-Gate gilt **ausschließlich für den Log-Sync-Kanal**:
+
+- `log-entry/1.0`-Ingest erfordert einen gecachten **`write`**-Scope für `docId`. Fehlt er → `CAPABILITY_REQUIRED`.
+- `sync-request` erfordert einen gecachten **`read`**-Scope für `docId`. Fehlt er → `CAPABILITY_REQUIRED`.
+
+Der **Inbox-Kanal** (`inbox/1.0`, `space-invite/1.0`, `member-update/1.0`, `key-rotation/1.0`, `ack/1.0`) ist **NICHT** capability-gated — sonst könnte ein frischer Client nie die erste Capability erhalten (Cold-Start). Inbox-Nachrichten sind ECIES-verschlüsselt und tragen ihre Autorität im inneren JWS.
 
 `validUntil` begrenzt Zugriffsrechte ohne explizite Rotation. Aktive Members bekommen rechtzeitig eine erneuerte Capability; inaktive Members verlieren den Broker-Zugriff automatisch.
 
@@ -277,44 +288,61 @@ Wenn ein Client ein Dokument syncen will:
 
 Bei Member-Entfernung rotiert der Admin das **Space Capability Key Pair**. Der Broker akzeptiert ab dem Moment nur Capabilities die gegen den neuen `spaceCapabilityVerificationKey` verifizierbar sind — alle alten Capabilities werden automatisch ungültig.
 
-Der Admin sendet dem Broker eine `space-rotate`-Nachricht:
+Der Admin sendet dem Broker einen `space-rotate`-Control-Frame. Wie alle Broker-Management-Frames trägt er seinen Claim als **Inner-JWS** (analog `device-revoke`), signiert mit dem space-spezifisch abgeleiteten **Admin Key**:
 
 ```json
 {
   "type": "space-rotate",
-  "spaceId": "7f3a2b10-...",
-  "newPublicKey": "<base64url>",
-  "newGeneration": 4
+  "rotationJws": "<JWS Compact Serialization>"
 }
 ```
 
-Signiert mit dem **Admin Key** (space-spezifisch abgeleitet). Der Broker akzeptiert die Nachricht nur wenn der Admin Key zur registrierten Admin-Liste dieses Space gehört.
+Der dekodierte JWS-Payload MUSS exakt `{ "type": "space-rotate", "spaceId": "<uuid>", "newPublicKey": "<base64url>", "newGeneration": <int> }` sein; der JWS-`kid` referenziert die signierende `adminDid`. Der Broker akzeptiert die Nachricht nur, wenn die `adminDid` zur registrierten Admin-Liste dieses Space gehört (sonst `AUTH_INVALID`) und `newGeneration` exakt die aktuelle Generation plus eins ist.
+
+**Cache-Invalidierung bei Rotation (MUSS, sicherheitskritisch).** Nach erfolgreicher `space-rotate`-Verarbeitung MUSS der Broker **sofort alle gecachten Capability-Scopes für diese `spaceId` mit `generation < newGeneration` über ALLE offenen WebSockets ALLER betroffenen DIDs invalidieren** — nicht erst beim nächsten Reconnect und nicht erst bei `validUntil`. Andernfalls könnte ein gerade entfernter Member über seinen noch offenen Socket weiter in den durablen Log schreiben; Member-Entfernung ist der einzige Zweck der Rotation und liefe sonst ins Leere. Ein Schreib-/Leseversuch mit einer Capability alter Generation wird mit `CAPABILITY_GENERATION_STALE` abgelehnt; der Client muss eine erneuerte Capability beschaffen und neu `present-capability`-en.
+
+### Space-Registrierung (`space-register`)
+
+Beim Erstellen eines Space registriert der Ersteller ihn beim Broker (Detail-Shape siehe [Sync 005](005-gruppen.md#initiale-space-registrierung)). Wie alle Broker-Management-Frames trägt `space-register` seinen Claim als **Inner-JWS**, signiert mit dem (noch einzigen) **Admin Key**:
+
+```json
+{
+  "type": "space-register",
+  "registrationJws": "<JWS Compact Serialization>"
+}
+```
+
+Der JWS-Payload MUSS `{ "type": "space-register", "spaceId": "<uuid>", "spaceCapabilityVerificationKey": "<base64url>", "adminDids": ["did:key:..."] }` sein.
+
+**Trust-on-first-use + Konfliktregel (MUSS).** Beim Erst-Register existiert noch keine Admin-Liste, gegen die der Broker prüfen könnte. Der Broker verifiziert daher nur, dass der JWS gegen eine der im Payload genannten `adminDids` signiert ist (self-asserting), und bindet dann `(spaceId → spaceCapabilityVerificationKey, adminDids)` **first-writer-wins**:
+
+- Ein späterer `space-register` für dieselbe `spaceId` mit **identischem** Inhalt → idempotent akzeptieren.
+- Ein späterer `space-register` mit **abweichendem** `spaceCapabilityVerificationKey` oder Admin-Set → **ablehnen** mit `SPACE_ALREADY_REGISTERED`. Änderungen laufen ausschließlich über die signierten Frames `space-rotate`/`admin-add`/`admin-remove`.
+
+`spaceId` ist eine nicht-ratbare zufällige UUID v4; Pre-Squatting setzt Kenntnis der `spaceId` voraus (Insider). Bei vollständigem Verlust des Broker-State DARF ein aktueller Admin den Space identisch re-registrieren (idempotenter Recovery-Pfad).
 
 ### Admin-Management
 
-Admins können weitere Admins hinzufügen oder entfernen:
+Admins können weitere Admins hinzufügen oder entfernen. Beide Frames tragen ihren Claim als **Inner-JWS**, signiert mit einem **bestehenden Admin Key** für diesen Space (sonst `AUTH_INVALID`):
 
 ```json
-{
-  "type": "admin-add",
-  "spaceId": "7f3a2b10-...",
-  "newAdminDid": "did:key:z6Mk...derived-for-space"
-}
+{ "type": "admin-add", "adminChangeJws": "<JWS Compact Serialization>" }
 ```
 
 ```json
-{
-  "type": "admin-remove",
-  "spaceId": "7f3a2b10-...",
-  "removedAdminDid": "did:key:z6Mk...derived-for-space"
-}
+{ "type": "admin-remove", "adminChangeJws": "<JWS Compact Serialization>" }
 ```
 
-Beide Nachrichten müssen mit einem **bestehenden Admin Key** für diesen Space signiert sein.
+Der JWS-Payload MUSS exakt `{ "type": "admin-add", "spaceId": "<uuid>", "newAdminDid": "did:key:..." }` bzw. `{ "type": "admin-remove", "spaceId": "<uuid>", "removedAdminDid": "did:key:..." }` sein; der JWS-`kid` referenziert die signierende `adminDid`.
 
 ### Persönliche Dokumente
 
-Für das persönliche Dokument (Identität, Keys) stellt der User sich seine eigene Capability aus. Das persönliche Dokument hat kein Space Capability Key Pair — stattdessen signiert der User die Capability direkt mit seinem **Identity Key** (DID). Der Broker prüft: `issuer` = `audience` = authentifizierte DID.
+Für das persönliche Dokument (Identität, Keys) stellt der User sich seine eigene Capability aus. Das persönliche Dokument hat kein Space Capability Key Pair — stattdessen signiert der User die Capability direkt mit seinem **Identity Key** (DID).
+
+**Broker-Erkennung (MUSS).** Der Broker unterscheidet den Pfad anhand der `space-register`-Eintragung für die `docId`:
+
+- Existiert **keine** `space-register`-Eintragung für `docId` → Personal-Doc-Pfad: Der Broker resolved die authentifizierte DID zu ihrem Ed25519 Identity Key, verifiziert das Capability-JWS damit und prüft `issuer` = `audience` = authentifizierte DID. Der Broker kann **nicht** kryptographisch beweisen, dass `docId` die deterministische Personal-Doc-ID *dieser* DID ist (sie ist seed-abgeleitet, broker-blind); das ist unkritisch, weil der Personal-Pfad ausschließlich Selbst-Autorisierung erlaubt (`issuer==audience==auth-DID`) und Personal-Doc-Inhalt unter einem nur dem Eigentümer bekannten Schlüssel liegt.
+- Existiert **eine** `space-register`-Eintragung für `docId` → greift **nur** der Space-Pfad; ein self-issued-Versuch auf eine registrierte `docId` wird abgelehnt. Damit kann der Personal-Pfad keine Space-`docId` umgehen.
 
 **Unterschied zum Space-Capability-Modell:** Bei Spaces signiert der geteilte `spaceCapabilitySigningKey`, bei Personal Docs signiert der persönliche Identity Key (DID). Das ist eine bewusste Vereinfachung — ein Personal Doc hat genau einen Eigentümer, kein Gruppen-Key-Management nötig. Die Capability-Felder (`spaceId`, `generation`, `validUntil`) werden analog verwendet, aber `spaceId` wird durch die deterministische Personal-Doc-ID ersetzt (siehe [Sync 006](006-personal-doc.md)).
 
@@ -429,9 +457,12 @@ Die folgende Tabelle ist normativ. Eine Implementation MUSS diese Authentisierun
 | Control-Frame | `challenge-response` | Explizites `signature`-Feld im Frame: unpadded Base64URL einer Ed25519-Signatur über den JCS-kanonisierten Broker-Auth-Transcript (siehe [Wire-Encoding der signature](#wire-encoding-der-signature-muss)) | (kein Envelope) |
 | Control-Frame | `registered` | Authentifizierter WebSocket-Kontext (post-handshake) | (kein Envelope) |
 | Control-Frame | `device-revoke` | Inner JWS gegen den Identity Key der `did` (persistenter Revocation-Claim) | (kein Envelope) |
+| Control-Frame | `present-capability` | Inner Capability-JWS im Frame; Broker verifiziert gegen `spaceCapabilityVerificationKey` (Space) bzw. Identity Key der DID (Personal-Doc) | (kein Envelope) |
+| Control-Frame | `space-register` | Inner JWS gegen einen der genannten `adminDids` (TOFU, first-writer-wins) | (kein Envelope) |
+| Control-Frame | `space-rotate`, `admin-add`, `admin-remove` | Inner JWS gegen einen **registrierten Admin Key** des Space | (kein Envelope) |
 | Control-Frame | `error/1.0` | Authentifizierter WebSocket-Kontext, Broker→Client (Broker spricht in seinem eigenen Namen) | (kein Envelope) |
 
-**Konsequenz für Control-Frames:** nur `challenge-response` und `device-revoke` tragen eigene Signaturen, weil sie kryptographische Claims machen, die vor oder über den Kanal hinaus gelten. Alle anderen Control-Frames sind reine Transport-Steuerung und brauchen keine zusätzliche Signatur.
+**Konsequenz für Control-Frames:** `challenge-response`, `device-revoke`, `present-capability`, `space-register`, `space-rotate`, `admin-add` und `admin-remove` tragen eigene Signaturen, weil sie kryptographische Claims machen, die vor oder über den Kanal hinaus gelten. Alle übrigen Control-Frames (`register`, `challenge`, `registered`, `error/1.0`) sind reine Transport-Steuerung und brauchen keine zusätzliche Signatur. Capability-JWS und Admin-Claim-JWS sind persistente WoT-Objekte, die hier — wie der Revocation-Claim bei `device-revoke` — als opaker String in einem transienten Control-Frame transportiert werden; das verletzt die Control-Frame-Definition nicht (der Frame trägt keine Transport-Envelope-Felder).
 
 ### Signatur (WoT Envelope-JWS)
 
@@ -662,6 +693,10 @@ Control-Frame-`type` MUSS aus folgendem geschlossenem Vokabular kommen:
 | `challenge-response` | Client→Broker | Client beweist DID-Besitz | `did`, `deviceId`, `nonce`, `signature` (siehe [Wire-Encoding der signature](#wire-encoding-der-signature-muss)) |
 | `registered` | Broker→Client | Broker bestätigt erfolgreiche Auth | `did`, `deviceId`, `isNewDevice` |
 | `device-revoke` | Client→Broker | Signierter Revocation-Claim für eine Device-ID dieser DID | `revocationJws`; keine weiteren Top-Level-Felder (siehe [Device-Deaktivierung](#device-deaktivierung)) |
+| `present-capability` | Client→Broker | Session-scoped Capability-Präsentation für eine `docId` | `capabilityJws`; keine weiteren Top-Level-Felder (siehe [Capability-Prüfung](#capability-prüfung-am-broker)) |
+| `space-register` | Client→Broker | Erst-Registrierung eines Space (TOFU, first-writer-wins) | `registrationJws`; keine weiteren Top-Level-Felder |
+| `space-rotate` | Client→Broker | Rotation des Space Capability Verification Key (Admin-signiert) | `rotationJws`; keine weiteren Top-Level-Felder |
+| `admin-add` / `admin-remove` | Client→Broker | Admin-Liste eines Space ändern (Admin-signiert) | `adminChangeJws`; keine weiteren Top-Level-Felder |
 | `error/1.0` | Broker→Client | Fehlerrückmeldung auf eine vorherige Nachricht | `thid` (Referenz auf ursprüngliche Anfrage), `body.code`, `body.message` |
 
 Implementierungen MÜSSEN unbekannte Frame-Types als `MALFORMED_MESSAGE` ablehnen — Control-Frames sind **nicht erweiterbar** durch Drittparteien.
@@ -695,9 +730,12 @@ Normative Error-Codes:
 | Code | Wann |
 |------|------|
 | `DOC_NOT_FOUND` | Dokument existiert beim Broker nicht |
+| `CAPABILITY_REQUIRED` | Für `log-entry`-Ingest (`write`) oder `sync-request` (`read`) wurde keine gültige Capability dieser Session präsentiert (kein gecachter Scope für `docId`) |
 | `CAPABILITY_INVALID` | Capability-Signatur ungültig |
 | `CAPABILITY_EXPIRED` | Capability abgelaufen |
 | `CAPABILITY_GENERATION_STALE` | Capability für alte Space-Keypair-Generation (nach Rotation) |
+| `SPACE_ALREADY_REGISTERED` | `space-register` für eine bereits mit abweichendem Verification Key / Admin-Set registrierte `spaceId` (first-writer-wins) |
+| `AUTHOR_MISMATCH` | Log-Eintrag-`authorKid`-DID ist nicht die für `deviceId` registrierte DID (Device-Registrierungs-Bindung) |
 | `DEVICE_NOT_REGISTERED` | Client-Device ist beim Broker nicht registriert |
 | `DEVICE_REVOKED` | Device-ID ist als revoked markiert |
 | `DEVICE_ID_CONFLICT` | Device-ID bereits für eine andere DID registriert |

--- a/03-wot-sync/003-transport-und-broker.md
+++ b/03-wot-sync/003-transport-und-broker.md
@@ -299,7 +299,7 @@ Der Admin sendet dem Broker einen `space-rotate`-Control-Frame. Wie alle Broker-
 }
 ```
 
-Der dekodierte JWS-Payload MUSS exakt `{ "type": "space-rotate", "spaceId": "<uuid>", "newPublicKey": "<base64url>", "newGeneration": <int> }` sein; der JWS-`kid` referenziert die signierende `adminDid`. Der Broker akzeptiert die Nachricht nur, wenn die `adminDid` zur registrierten Admin-Liste dieses Space gehört (sonst `AUTH_INVALID`) und `newGeneration` exakt die aktuelle Generation plus eins ist.
+Der dekodierte JWS-Payload MUSS exakt `{ "type": "space-rotate", "spaceId": "<uuid>", "newSpaceCapabilityVerificationKey": "<base64url>", "newGeneration": <int> }` sein; der JWS-`kid` referenziert die signierende `adminDid`. `newSpaceCapabilityVerificationKey` ist der kanonische Feldname (parallel zu `spaceCapabilityVerificationKey` bei `space-register`, mit `new`-Präfix wie `newGeneration`) — derselbe Wire-Contract, ein Feldname. Der Broker akzeptiert die Nachricht nur, wenn die `adminDid` zur registrierten Admin-Liste dieses Space gehört (sonst `AUTH_INVALID`) und `newGeneration` exakt die aktuelle Generation plus eins ist.
 
 **Cache-Invalidierung bei Rotation (MUSS, sicherheitskritisch).** Nach erfolgreicher `space-rotate`-Verarbeitung MUSS der Broker **sofort alle gecachten Capability-Scopes für diese `spaceId` mit `generation < newGeneration` über ALLE offenen WebSockets ALLER betroffenen DIDs invalidieren** — nicht erst beim nächsten Reconnect und nicht erst bei `validUntil`. Andernfalls könnte ein gerade entfernter Member über seinen noch offenen Socket weiter in den durablen Log schreiben; Member-Entfernung ist der einzige Zweck der Rotation und liefe sonst ins Leere. Ein Schreib-/Leseversuch mit einer Capability alter Generation wird mit `CAPABILITY_GENERATION_STALE` abgelehnt; der Client muss eine erneuerte Capability beschaffen und neu `present-capability`-en.
 
@@ -322,6 +322,8 @@ Der JWS-Payload MUSS `{ "type": "space-register", "spaceId": "<uuid>", "spaceCap
 - Ein späterer `space-register` mit **abweichendem** `spaceCapabilityVerificationKey` oder Admin-Set → **ablehnen** mit `SPACE_ALREADY_REGISTERED`. Änderungen laufen ausschließlich über die signierten Frames `space-rotate`/`admin-add`/`admin-remove`.
 
 `spaceId` ist eine nicht-ratbare zufällige UUID v4; Pre-Squatting setzt Kenntnis der `spaceId` voraus (Insider). Bei vollständigem Verlust des Broker-State DARF ein aktueller Admin den Space identisch re-registrieren (idempotenter Recovery-Pfad).
+
+**Scope-Invalidierung bei Erst-Register (MUSS).** Vor der ersten `space-register`-Verarbeitung gilt eine `docId` als Personal-Doc (kein Registereintrag), sodass Sockets self-issued Personal-Scopes dafür cachen könnten. Nach erfolgreichem initialem `space-register` für eine `docId` MUSS der Broker daher alle zuvor für diese `docId` gecachten **Personal-Doc-Scopes** über ALLE offenen WebSockets verwerfen (analog zur [Cache-Invalidierung bei Rotation](#capability-widerruf-über-rotation)). Folgezugriffe MÜSSEN über den Space-Pfad neu `present-capability`-en. Andernfalls könnte ein Socket mit einem vor dem Register gecachten Personal-Scope den Space-Pfad-Zwang („Existiert eine `space-register`-Eintragung → nur Space-Pfad") auf einer offenen Verbindung umgehen.
 
 ### Admin-Management
 

--- a/03-wot-sync/005-gruppen.md
+++ b/03-wot-sync/005-gruppen.md
@@ -286,7 +286,7 @@ Alte Daten bleiben mit alten Space Content Keys lesbar. Rotation schuetzt nur zu
 
 - `generation` MUSS exakt die vorherige Space-Key-Generation plus eins sein.
 - Die enthaltene `capability.generation` MUSS `generation` entsprechen.
-- Der Broker MUSS nach erfolgreicher `space-rotate` Verarbeitung alte Capabilities ablehnen (`CAPABILITY_GENERATION_STALE`).
+- Der Broker MUSS nach erfolgreicher `space-rotate` Verarbeitung alte Capabilities ablehnen (`CAPABILITY_GENERATION_STALE`) und gecachte Capability-Scopes alter Generation **sofort über alle offenen Sockets invalidieren** (siehe [Sync 003 Capability-Widerruf über Rotation](003-transport-und-broker.md#capability-widerruf-über-rotation)) — sonst könnte ein entfernter Member über einen noch offenen Socket weiterschreiben.
 - Clients MUESSEN neue Log-Eintraege nach Rotation mit der neuen `keyGeneration` schreiben.
 - Clients MUESSEN alte Log-Eintraege weiter mit der jeweils im Log-Eintrag angegebenen historischen `keyGeneration` entschluesseln.
 
@@ -318,7 +318,16 @@ Gleichzeitige Einladungen sind unabhängige CRDT-Operationen. Wenn Einladung und
 
 ### Initiale Space-Registrierung
 
-Wenn ein User einen Space erstellt, registriert er ihn beim Broker:
+Wenn ein User einen Space erstellt, registriert er ihn beim Broker. `space-register` ist ein Broker-Control-Frame und trägt seinen Claim — wie alle Broker-Management-Frames — als **Inner-JWS** (Familienzuordnung + Authentizität siehe [Sync 003](003-transport-und-broker.md#space-registrierung-space-register)):
+
+```json
+{
+  "type": "space-register",
+  "registrationJws": "<JWS Compact Serialization>"
+}
+```
+
+Der dekodierte JWS-Payload MUSS exakt sein:
 
 ```json
 {
@@ -329,7 +338,7 @@ Wenn ein User einen Space erstellt, registriert er ihn beim Broker:
 }
 ```
 
-Signiert mit dem (noch einzigen) Admin Key. Der Broker akzeptiert die Registrierung, speichert Space-ID, Space Capability Verification Key und Admin-DIDs. Später können Admins hinzugefügt, entfernt oder das Capability Key Pair rotiert werden (jeweils signiert von einem eingetragenen Admin).
+Signiert mit dem (noch einzigen) Admin Key; der JWS-`kid` referenziert eine der genannten `adminDids`. Da beim Erst-Register noch keine Admin-Liste existiert, ist die Registrierung **trust-on-first-use** und wird **first-writer-wins** gebunden: ein späterer `space-register` mit identischem Inhalt ist idempotent, mit abweichendem `spaceCapabilityVerificationKey`/Admin-Set wird er mit `SPACE_ALREADY_REGISTERED` abgelehnt (Detail siehe [Sync 003](003-transport-und-broker.md#space-registrierung-space-register)). Der Broker speichert Space-ID, Space Capability Verification Key und Admin-DIDs. Spätere Änderungen laufen ausschließlich über die signierten Frames `admin-add`/`admin-remove`/`space-rotate` (jeweils signiert von einem eingetragenen Admin).
 
 ### Capability-Prüfung
 

--- a/03-wot-sync/006-personal-doc.md
+++ b/03-wot-sync/006-personal-doc.md
@@ -293,17 +293,20 @@ Es gibt keine Personal-Doc-Key-Rotation im normalen Betrieb; der Key ändert sic
 
 ## Capability-Modell
 
-Der User ist sein eigener Admin für das Personal Doc. Broker prüfen self-issued Capabilities (siehe [Sync 003](003-transport-und-broker.md#autorisierung-capabilities)):
+Der User ist sein eigener Admin für das Personal Doc. Die Personal-Doc-Capability nutzt **dasselbe Payload-Schema** wie die Space-Capability (normative Wire-Form siehe [Sync 003 Persönliche Dokumente](003-transport-und-broker.md#persönliche-dokumente)) mit festen Bindungen:
 
 ```
-Personal Doc Capability:
-  issuer   = did:key:z6Mk...alice (der User selbst)
-  audience = did:key:z6Mk...alice (derselbe User)
-  docId    = <deterministische Personal Doc ID>
+Personal Doc Capability (Payload):
+  type        = "capability"
+  spaceId     = <deterministische Personal Doc ID>   (= docId)
+  audience    = did:key:z6Mk...alice                  (der User selbst)
   permissions = ["read", "write"]
+  generation  = 0                                     (Personal-Docs werden nicht rotiert)
+  issuedAt / validUntil = wie bei Space-Capabilities
+  kid (Header) = <did>#<vm>                           (Identity-Key, NICHT wot:space:…)
 ```
 
-Die Capability ist self-issued, vom User selbst signiert und kann jederzeit neu ausgestellt werden.
+Die Capability ist self-issued, mit dem **Identity Key** des Users signiert (kein separates `issuer`-Feld — der Issuer ist implizit die `kid`-DID), und kann jederzeit neu ausgestellt werden. Der Broker prüft `kid`-DID = `audience` = authentifizierte DID und `spaceId` = `docId`.
 
 ## Recovery
 


### PR DESCRIPTION
## Was & Warum

Schließt die **Broker-Ingest-Autorisierungslücke** vor dem vNext-Cutover: heute prüft der Relay (durable-log, Slice R) **keine** Capabilities und bindet `authorKid` nicht an die registrierte `deviceId`. Diese Spec-Änderung macht den Capability-gated Ingest + die Provisioning-Frames + die Autor-Bindung normativ — Voraussetzung für einen 100% spec-konformen Cutover **ohne** zweiten Protokollbruch.

Dual-reviewt (Codex + Opus), alle Entscheidungen mit Anton abgestimmt.

## Spec-Anker

- **Sync 002** §docId-und-spaceId (neu): `docId == spaceId` für Space-Docs; Personal-Doc = deterministische ID; native CRDT-IDs intern mappen.
- **Sync 003** §104-184 (Log-Eintrag-Autor-Bindung), §210-345 (Capability-Prüfung/Rotation/space-register/admin/Personal-Doc), §408-434 (Authentizitätsmatrix), §640-712 (Control-Frame-Vokabular + Error-Codes).
- **Sync 005** §317-340 (space-register Inner-JWS + TOFU), §285-291 (Rotation-Invarianten).
- **Sync 001** §179-224 (Admin-Key seed-abgeleitet, Capability-Keypair zufällig+verteilt) — unverändert, als Grundlage referenziert.

## Entscheidungen (Kurzfassung)

| | Entscheidung |
|---|---|
| **A** | `docId == spaceId` für Spaces normieren; Capability bindet an `docId`; Multi-Doc-per-Space = künftige Extension mit explizitem Mapping |
| **B1** | 5 Frames (`space-register`/`space-rotate`/`admin-add`/`admin-remove`/`present-capability`) ins geschlossene Control-Frame-Vokabular + Authentizitätsmatrix |
| **B2** | Admin/Capability-Claims als **Inner-JWS** (`{type, <claim>Jws}`, analog `device-revoke`) — eine Signaturkonvention |
| **B3** | `space-register` = TOFU + **first-writer-wins** (`SPACE_ALREADY_REGISTERED`); Änderungen nur über signierte Admin-Frames |
| **C1** | `present-capability` **session-scoped**; Scope-Cache pro `(WebSocket, docId)` mit `permissions` + `generation` |
| **C2** | `space-rotate` MUSS **sofort** gecachte Scopes alter Generation über alle Sockets aller DIDs invalidieren (echtes Member-Removal) |
| **C3** | Gate **nur** Log-Sync (`log-entry`=write, `sync-request`=read); **Inbox ungated** (Cold-Start) |
| **C4** | Space- vs. Personal-Doc-Pfad-Erkennung via `space-register`-Eintrag; Personal = self-issued (`issuer==audience==DID`) |
| **F** | Log-Eintrag-Autor-Bindung: `authorKid`-DID == registrierte DID der `deviceId` (`AUTHOR_MISMATCH`); ersetzt brokerlokale First-Writer-Wins-Heuristik (VE-3a) |

Neue Error-Codes: `CAPABILITY_REQUIRED`, `SPACE_ALREADY_REGISTERED`, `AUTHOR_MISMATCH`.

## Issues

`Closes #84` (Familienzuordnung + Signatur-Envelope der Admin-Frames — hier als Inner-JWS-Control-Frame definiert) · `Closes #105` (Ingest-Autorisierung authorKid↔deviceId↔Capability).

**#85-89** sind Near-Duplikate von #84 (gleiches Wire-Format-Thema): die **normative Form** ist hier definiert; die **Conformance-Vektoren** entstehen im Referenz-Impl-Slice (Capability-Gate). Vorschlag: #85-89 als Duplikate von #84 schließen.

## Scope / Nicht in diesem PR

- **Conformance-Vektoren** der neuen Frames → entstehen mit dem Impl-Slice (Vektoren = Output der Referenz-Impl).
- **Impl** (Relay-Verdrahtung: present-capability, Scope-Cache, Rotation, space-register, Autor-Bindung; Automerge UUID-docId) → gebündelter Slice nach Merge.

## Bekannte Grenze (Shared-Seed)

Der Gate ist ein **Membership-Filter** (fremde DIDs raus), **kein** Insider-/Seed-Kompromittierungs-Schutz: im Shared-Seed teilen alle dieselbe DID. Geräte-granulare Autorität erst mit per-device Keys (Identity 004 / Phase 2).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Strengthened security requirements for document identity and capability authorization semantics
  * Enhanced space registration with trust-on-first-use and idempotency behavior
  * Added broker-enforced author validation and session-scoped capability scope caching
  * Extended error codes for authorization and validation scenarios
  * Clarified capability revocation and cache invalidation during key rotation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->